### PR TITLE
Fixed YouTube Parsing to Workt with -'s in id

### DIFF
--- a/src/org/xbmc/android/util/YoutubeURLParser.java
+++ b/src/org/xbmc/android/util/YoutubeURLParser.java
@@ -10,7 +10,7 @@ public class YoutubeURLParser {
 		if (playuri.getHost().endsWith("youtube.com") || playuri.getHost().endsWith("youtu.be")) {
 			// We'll need to get the v= parameter from the URL and use
 			// that to send to XBMC
-			final Pattern pattern = Pattern.compile("^http(:?s)?:\\/\\/(?:www\\.)?(?:youtube\\.com|youtu\\.be)\\/watch\\?(?=.*v=(\\w+))(?:\\S+)?$", Pattern.CASE_INSENSITIVE);
+			final Pattern pattern = Pattern.compile("^http(:?s)?:\\/\\/(?:www\\.)?(?:youtube\\.com|youtu\\.be)\\/watch\\?(?=.*v=([\\w-]+))(?:\\S+)?$", Pattern.CASE_INSENSITIVE);
 //			final Pattern pattern = Pattern.compile(".*v=([a-z0-9_\\-]+)(?:&.)*", Pattern.CASE_INSENSITIVE);
 			final Matcher matcher = pattern.matcher(playuri.toString());
 			if (matcher.matches()) {


### PR DESCRIPTION
previously the regex only supported /w. I have added - to the regex. For example see: http://www.youtube.com/watch?v=u-yLGIH7W9Y
