### PR TITLE
Fixed issues with Specials in TV Seasons, display of thumbnail on now playing screen, Added pre-fetching of covers on lists

### DIFF
--- a/src/org/xbmc/android/remote/business/AbstractManager.java
+++ b/src/org/xbmc/android/remote/business/AbstractManager.java
@@ -155,11 +155,16 @@ public abstract class AbstractManager implements INotifiableManager {
 		}
 	}
 	public Bitmap getCoverSync(final ICoverArt cover, final int thumbSize){
-		return MemCacheThread.getCover(cover, thumbSize);
+		if(MemCacheThread.isInCache(cover, thumbSize))
+			return MemCacheThread.getCover(cover, thumbSize);
+		else if(DiskCacheThread.isInCache(cover, thumbSize))
+			return DiskCacheThread.getCover(cover, thumbSize);
+		else
+			return null;			
 	}
 	
 	public boolean coverLoaded(final ICoverArt cover, final int thumbSize){
-		return MemCacheThread.isInCache(cover, thumbSize);
+		return (MemCacheThread.isInCache(cover, thumbSize) || DiskCacheThread.isInCache(cover, thumbSize));
 	}
 	
 	/**

--- a/src/org/xbmc/android/remote/business/AbstractManager.java
+++ b/src/org/xbmc/android/remote/business/AbstractManager.java
@@ -154,6 +154,13 @@ public abstract class AbstractManager implements INotifiableManager {
 			//mHandler.post(response);
 		}
 	}
+	public Bitmap getCoverSync(final ICoverArt cover, final int thumbSize){
+		return MemCacheThread.getCover(cover, thumbSize);
+	}
+	
+	public boolean coverLoaded(final ICoverArt cover, final int thumbSize){
+		return MemCacheThread.isInCache(cover, thumbSize);
+	}
 	
 	/**
 	 * Returns bitmap of any cover. Note that the callback is done by the
@@ -335,6 +342,11 @@ public abstract class AbstractManager implements INotifiableManager {
 	 */
 	public void setSortKey(int sortKey) {
 		mCurrentSortKey = sortKey;
+	}
+	
+	public void post(Runnable runnable)
+	{
+		mHandler.post(runnable);
 	}
 	
 	/**

--- a/src/org/xbmc/android/remote/business/CacheManager.java
+++ b/src/org/xbmc/android/remote/business/CacheManager.java
@@ -1,0 +1,23 @@
+package org.xbmc.android.remote.business;
+
+import org.xbmc.android.util.ImportUtilities;
+
+public class CacheManager {
+	private static CacheManager instance;
+	
+	private CacheManager() {		
+	}
+	
+	public static CacheManager get() {
+		if(instance == null) {
+			instance = new CacheManager();
+		}
+		
+		return instance;
+	}
+	
+	public void purgeCache() {
+		ImportUtilities.purgeCache();
+		MemCacheThread.purgeCache();
+	}
+}

--- a/src/org/xbmc/android/remote/business/EventClientManager.java
+++ b/src/org/xbmc/android/remote/business/EventClientManager.java
@@ -96,6 +96,14 @@ public class EventClientManager implements INotifiableManager, IEventClientManag
 	public void getCover(DataResponse<Bitmap> response, ICoverArt cover, int thumbSize, Bitmap defaultCover, final Context context, boolean b) {
 		// only a stub;
 	}
+	
+	public Bitmap getCoverSync(final ICoverArt cover, final int thumbSize) {
+		return null;
+	}
+	
+	public boolean coverLoaded(final ICoverArt cover, final int thumbSize) {
+		return false;
+	}
 
 	public void onWrongConnectionState(int state) {
 		if (mController != null) {
@@ -111,6 +119,10 @@ public class EventClientManager implements INotifiableManager, IEventClientManag
 	public void onWrongConnectionState(int state, Command<?> cmd) {
 		// TODO Auto-generated method stub
 		
+	}
+	
+	public void post(Runnable r) {
+		// TODO Auto-generated method stub
 	}
 
 	public void retryAll() {

--- a/src/org/xbmc/android/remote/business/MemCacheThread.java
+++ b/src/org/xbmc/android/remote/business/MemCacheThread.java
@@ -156,4 +156,10 @@ class MemCacheThread extends AbstractThread {
 			sHttpApiThread = null;
 		}
 	}
+	
+	public static void purgeCache() {
+		sCacheMedium.clear();
+		sCacheSmall.clear();
+		sNotAvailable.clear();
+	}
 }

--- a/src/org/xbmc/android/remote/presentation/activity/AboutActivity.java
+++ b/src/org/xbmc/android/remote/presentation/activity/AboutActivity.java
@@ -24,6 +24,7 @@ package org.xbmc.android.remote.presentation.activity;
 import org.xbmc.android.remote.R;
 import org.xbmc.android.remote.business.ManagerFactory;
 import org.xbmc.api.business.IEventClientManager;
+import org.xbmc.api.type.ThumbSize;
 import org.xbmc.eventclient.ButtonCodes;
 
 import android.app.Activity;
@@ -31,6 +32,7 @@ import android.content.pm.PackageManager.NameNotFoundException;
 import android.os.Bundle;
 import android.text.Html;
 import android.text.method.LinkMovementMethod;
+import android.view.Display;
 import android.view.KeyEvent;
 import android.widget.TextView;
 
@@ -43,6 +45,10 @@ public class AboutActivity extends Activity {
 	public void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
 		setContentView(R.layout.about);
+		// set display size
+		final Display display = getWindowManager().getDefaultDisplay(); 
+		ThumbSize.setScreenSize(display.getWidth(), display.getHeight());
+		
 		try {
 			mEventClientManager = ManagerFactory.getEventClientManager(null);
 			final String versionName = getPackageManager().getPackageInfo(getPackageName(), 0).versionName;

--- a/src/org/xbmc/android/remote/presentation/activity/AbsListActivity.java
+++ b/src/org/xbmc/android/remote/presentation/activity/AbsListActivity.java
@@ -29,15 +29,18 @@ import org.xbmc.android.util.KeyTracker;
 import org.xbmc.android.util.KeyTracker.Stage;
 import org.xbmc.android.util.OnLongPressBackKeyTracker;
 import org.xbmc.api.business.IEventClientManager;
+import org.xbmc.api.type.ThumbSize;
 import org.xbmc.eventclient.ButtonCodes;
 
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Build.VERSION;
+import android.os.Bundle;
 import android.os.Handler;
 import android.view.ContextMenu;
 import android.view.ContextMenu.ContextMenuInfo;
+import android.view.Display;
 import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -73,6 +76,13 @@ public abstract class AbsListActivity extends Activity {
 				
 			});
 		}
+	}
+
+	protected void onCreate(Bundle savedInstanceState) {
+		super.onCreate(savedInstanceState);
+		// set display size
+		final Display display = getWindowManager().getDefaultDisplay(); 
+		ThumbSize.setScreenSize(display.getWidth(), display.getHeight());		
 	}
 	
 	protected void setupLists(int layoutResId) {

--- a/src/org/xbmc/android/remote/presentation/activity/EpisodeDetailsActivity.java
+++ b/src/org/xbmc/android/remote/presentation/activity/EpisodeDetailsActivity.java
@@ -46,6 +46,7 @@ import android.os.Build.VERSION;
 import android.os.Bundle;
 import android.os.Handler;
 import android.util.Log;
+import android.view.Display;
 import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -92,6 +93,10 @@ public class EpisodeDetailsActivity extends Activity {
 	public void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
 		setContentView(R.layout.tvepisodedetails);
+
+		// set display size
+		final Display display = getWindowManager().getDefaultDisplay(); 
+		ThumbSize.setScreenSize(display.getWidth(), display.getHeight());
 		
 		// remove nasty top fading edge
 		FrameLayout topFrame = (FrameLayout)findViewById(android.R.id.content);

--- a/src/org/xbmc/android/remote/presentation/activity/GestureRemoteActivity.java
+++ b/src/org/xbmc/android/remote/presentation/activity/GestureRemoteActivity.java
@@ -24,6 +24,7 @@ package org.xbmc.android.remote.presentation.activity;
 import org.xbmc.android.remote.R;
 import org.xbmc.android.remote.presentation.controller.RemoteController;
 import org.xbmc.android.widget.gestureremote.GestureRemoteView;
+import org.xbmc.api.type.ThumbSize;
 import org.xbmc.eventclient.ButtonCodes;
 
 import android.app.Activity;
@@ -61,6 +62,9 @@ public class GestureRemoteActivity extends Activity {
 		super.onCreate(savedInstanceState);
 		
 		Display d = getWindowManager().getDefaultDisplay();
+		// set display size
+		ThumbSize.setScreenSize(d.getWidth(), d.getHeight());
+		
 		final int w = d.getWidth();
 		final int h = d.getHeight();
 		final double ar = w > h ? (double) w / (double) h : (double) h / (double) w;

--- a/src/org/xbmc/android/remote/presentation/activity/HomeActivity.java
+++ b/src/org/xbmc/android/remote/presentation/activity/HomeActivity.java
@@ -22,10 +22,10 @@
 package org.xbmc.android.remote.presentation.activity;
 
 import org.xbmc.android.remote.R;
+import org.xbmc.android.remote.business.CacheManager;
 import org.xbmc.android.remote.business.ManagerFactory;
 import org.xbmc.android.remote.presentation.controller.HomeController;
 import org.xbmc.android.remote.presentation.controller.HomeController.ProgressThread;
-import org.xbmc.android.util.ImportUtilities;
 import org.xbmc.android.util.KeyTracker.Stage;
 import org.xbmc.android.util.OnLongPressBackKeyTracker;
 import org.xbmc.api.business.IEventClientManager;
@@ -172,7 +172,7 @@ public class HomeActivity extends Activity {
 			builder.setCancelable(false);
 			builder.setPositiveButton("Absolutely.", new DialogInterface.OnClickListener() {
 				public void onClick(DialogInterface dialog, int which) {
-					ImportUtilities.purgeCache();
+					CacheManager.get().purgeCache();
 					Toast.makeText(HomeActivity.this, "Cache purged.", Toast.LENGTH_SHORT).show();
 				}
 			});

--- a/src/org/xbmc/android/remote/presentation/activity/HostSettingsActivity.java
+++ b/src/org/xbmc/android/remote/presentation/activity/HostSettingsActivity.java
@@ -21,16 +21,16 @@
 
 package org.xbmc.android.remote.presentation.activity;
 
-import java.io.IOException;
-
 import org.xbmc.android.remote.business.ManagerFactory;
 import org.xbmc.android.remote.presentation.controller.SettingsController;
 import org.xbmc.api.business.IEventClientManager;
+import org.xbmc.api.type.ThumbSize;
 import org.xbmc.eventclient.ButtonCodes;
 
 import android.os.Bundle;
 import android.os.Handler;
 import android.preference.PreferenceActivity;
+import android.view.Display;
 import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -49,6 +49,10 @@ public class HostSettingsActivity extends PreferenceActivity {
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
+		// set display size
+		final Display display = getWindowManager().getDefaultDisplay(); 
+		ThumbSize.setScreenSize(display.getWidth(), display.getHeight());
+		
 		setTitle("XBMC Hosts");
 		mSettingsController = new SettingsController(this, new Handler());
 		mConfigurationManager = ConfigurationManager.getInstance(this);

--- a/src/org/xbmc/android/remote/presentation/activity/MediaIntentActivity.java
+++ b/src/org/xbmc/android/remote/presentation/activity/MediaIntentActivity.java
@@ -23,10 +23,12 @@ package org.xbmc.android.remote.presentation.activity;
 
 
 import org.xbmc.android.remote.presentation.controller.MediaIntentController;
+import org.xbmc.api.type.ThumbSize;
 
 import android.app.Activity;
 import android.os.Bundle;
 import android.os.Handler;
+import android.view.Display;
 
 /**
  * @author Team XBMC
@@ -42,6 +44,10 @@ public class MediaIntentActivity extends Activity {
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+		// set display size
+		final Display display = getWindowManager().getDefaultDisplay(); 
+		ThumbSize.setScreenSize(display.getWidth(), display.getHeight());
+		
   	  	mConfigurationManager = ConfigurationManager.getInstance(this);
 		mMediaIntentController = new MediaIntentController(this, new Handler());
 		mMediaIntentController.setupStatusHandler();

--- a/src/org/xbmc/android/remote/presentation/activity/MovieDetailsActivity.java
+++ b/src/org/xbmc/android/remote/presentation/activity/MovieDetailsActivity.java
@@ -48,6 +48,7 @@ import android.os.Build.VERSION;
 import android.os.Bundle;
 import android.os.Handler;
 import android.util.Log;
+import android.view.Display;
 import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -95,6 +96,10 @@ public class MovieDetailsActivity extends Activity {
 	public void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
 		setContentView(R.layout.moviedetails);
+
+		// set display size
+		final Display display = getWindowManager().getDefaultDisplay(); 
+		ThumbSize.setScreenSize(display.getWidth(), display.getHeight());	
 		
 		// remove nasty top fading edge
 		FrameLayout topFrame = (FrameLayout)findViewById(android.R.id.content);

--- a/src/org/xbmc/android/remote/presentation/activity/NowPlayingActivity.java
+++ b/src/org/xbmc/android/remote/presentation/activity/NowPlayingActivity.java
@@ -31,6 +31,7 @@ import org.xbmc.android.util.KeyTracker.Stage;
 import org.xbmc.android.util.OnLongPressBackKeyTracker;
 import org.xbmc.api.business.IEventClientManager;
 import org.xbmc.api.object.Song;
+import org.xbmc.api.type.ThumbSize;
 import org.xbmc.eventclient.ButtonCodes;
 
 import android.app.Activity;
@@ -40,6 +41,7 @@ import android.graphics.Bitmap;
 import android.os.Build.VERSION;
 import android.os.Bundle;
 import android.os.Handler;
+import android.view.Display;
 import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -91,6 +93,10 @@ public class NowPlayingActivity extends Activity {
 	public void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
 
+		// set display size
+		final Display display = getWindowManager().getDefaultDisplay(); 
+		ThumbSize.setScreenSize(display.getWidth(), display.getHeight());	
+		
 		setContentView(R.layout.nowplaying);
 
 		mNowPlayingController = new NowPlayingController(this, new Handler());

--- a/src/org/xbmc/android/remote/presentation/activity/PlaylistActivity.java
+++ b/src/org/xbmc/android/remote/presentation/activity/PlaylistActivity.java
@@ -28,6 +28,7 @@ import org.xbmc.android.util.KeyTracker;
 import org.xbmc.android.util.KeyTracker.Stage;
 import org.xbmc.android.util.OnLongPressBackKeyTracker;
 import org.xbmc.api.business.IEventClientManager;
+import org.xbmc.api.type.ThumbSize;
 import org.xbmc.eventclient.ButtonCodes;
 
 import android.app.Activity;
@@ -37,6 +38,7 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.view.ContextMenu;
 import android.view.ContextMenu.ContextMenuInfo;
+import android.view.Display;
 import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -81,6 +83,10 @@ public class PlaylistActivity extends Activity {
 	public void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
 		setContentView(R.layout.playlist);
+
+		// set display size
+		final Display display = getWindowManager().getDefaultDisplay(); 
+		ThumbSize.setScreenSize(display.getWidth(), display.getHeight());	
 		
 		// remove nasty top fading edge
 		FrameLayout topFrame = (FrameLayout)findViewById(android.R.id.content);

--- a/src/org/xbmc/android/remote/presentation/activity/RemoteActivity.java
+++ b/src/org/xbmc/android/remote/presentation/activity/RemoteActivity.java
@@ -26,6 +26,7 @@ import org.xbmc.android.remote.presentation.controller.RemoteController;
 import org.xbmc.android.util.KeyTracker;
 import org.xbmc.android.util.OnLongPressBackKeyTracker;
 import org.xbmc.android.util.KeyTracker.Stage;
+import org.xbmc.api.type.ThumbSize;
 import org.xbmc.eventclient.ButtonCodes;
 
 import android.app.Activity;
@@ -90,6 +91,8 @@ public class RemoteActivity extends Activity {
 		super.onCreate(savedInstanceState);
 		
 		Display d = getWindowManager().getDefaultDisplay();
+		// set display size
+		ThumbSize.setScreenSize(d.getWidth(), d.getHeight());	
 		final int w = d.getWidth();
 		final int h = d.getHeight();
 		final double ar = w > h ? (double) w / (double) h : (double) h / (double) w;

--- a/src/org/xbmc/android/remote/presentation/activity/SettingsActivity.java
+++ b/src/org/xbmc/android/remote/presentation/activity/SettingsActivity.java
@@ -25,12 +25,14 @@ import org.xbmc.android.remote.R;
 import org.xbmc.android.remote.business.ManagerFactory;
 import org.xbmc.android.remote.presentation.controller.SettingsController;
 import org.xbmc.api.business.IEventClientManager;
+import org.xbmc.api.type.ThumbSize;
 import org.xbmc.eventclient.ButtonCodes;
 
 import android.os.Bundle;
 import android.os.Handler;
 import android.preference.PreferenceActivity;
 import android.preference.PreferenceScreen;
+import android.view.Display;
 import android.view.KeyEvent;
 
 /**
@@ -56,6 +58,10 @@ public class SettingsActivity extends PreferenceActivity {
 	protected void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
 		addPreferencesFromResource(R.xml.preferences);
+
+		// set display size
+		final Display display = getWindowManager().getDefaultDisplay(); 
+		ThumbSize.setScreenSize(display.getWidth(), display.getHeight());	
 		
 		mSettingsController = new SettingsController(this, new Handler());
 		mSettingsController.registerOnSharedPreferenceChangeListener(this);

--- a/src/org/xbmc/android/remote/presentation/activity/TvShowDetailsActivity.java
+++ b/src/org/xbmc/android/remote/presentation/activity/TvShowDetailsActivity.java
@@ -47,6 +47,7 @@ import android.os.Build.VERSION;
 import android.os.Bundle;
 import android.os.Handler;
 import android.util.Log;
+import android.view.Display;
 import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -93,6 +94,10 @@ public class TvShowDetailsActivity extends Activity {
 	public void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
 		setContentView(R.layout.tvdetails);
+
+		// set display size
+		final Display display = getWindowManager().getDefaultDisplay(); 
+		ThumbSize.setScreenSize(display.getWidth(), display.getHeight());	
 		
 		// remove nasty top fading edge
 		FrameLayout topFrame = (FrameLayout)findViewById(android.R.id.content);

--- a/src/org/xbmc/android/remote/presentation/activity/UrlIntentActivity.java
+++ b/src/org/xbmc/android/remote/presentation/activity/UrlIntentActivity.java
@@ -23,10 +23,12 @@ package org.xbmc.android.remote.presentation.activity;
 
 
 import org.xbmc.android.remote.presentation.controller.UrlIntentController;
+import org.xbmc.api.type.ThumbSize;
 
 import android.app.Activity;
 import android.os.Bundle;
 import android.os.Handler;
+import android.view.Display;
 
 /**
  * @author Team XBMC
@@ -42,6 +44,9 @@ public class UrlIntentActivity extends Activity {
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+		// set display size
+		final Display display = getWindowManager().getDefaultDisplay(); 
+		ThumbSize.setScreenSize(display.getWidth(), display.getHeight());		
   	  	mConfigurationManager = ConfigurationManager.getInstance(this);
   	  	mUrlIntentController = new UrlIntentController(this, new Handler());
   	  	mUrlIntentController.setupStatusHandler();
@@ -60,5 +65,4 @@ public class UrlIntentActivity extends Activity {
 		mUrlIntentController.onActivityResume(this);
 		mConfigurationManager.onActivityResume(this);
 	}
-
 }

--- a/src/org/xbmc/android/remote/presentation/controller/ActorListController.java
+++ b/src/org/xbmc/android/remote/presentation/controller/ActorListController.java
@@ -39,7 +39,6 @@ import android.content.Intent;
 import android.graphics.BitmapFactory;
 import android.os.Handler;
 import android.view.ContextMenu;
-import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
@@ -89,7 +88,6 @@ public class ActorListController extends ListController implements IController {
 					if (value.size() > 0) {
 						setTitle(title + " (" + value.size() + ")");
 						mList.setAdapter(new ActorAdapter(mActivity, value));
-						preloadCovers(value, mVideoManager, mThumbSize);
 					} else {
 						setTitle(title);
 						setNoDataMessage("No actors found.", R.drawable.icon_artist_dark);
@@ -131,11 +129,7 @@ public class ActorListController extends ListController implements IController {
 			});
 		}
 	}
-	
-	@Override
-	public void onCreateOptionsMenu(Menu menu) {
-	}
-	
+		
 	private class ActorAdapter extends ArrayAdapter<Actor> {
 		ActorAdapter(Activity activity, ArrayList<Actor> items) {
 			super(activity, 0, items);

--- a/src/org/xbmc/android/remote/presentation/controller/ActorListController.java
+++ b/src/org/xbmc/android/remote/presentation/controller/ActorListController.java
@@ -89,7 +89,7 @@ public class ActorListController extends ListController implements IController {
 					if (value.size() > 0) {
 						setTitle(title + " (" + value.size() + ")");
 						mList.setAdapter(new ActorAdapter(mActivity, value));
-						cacheCovers(value, mVideoManager, mThumbSize);
+						preloadCovers(value, mVideoManager, mThumbSize);
 					} else {
 						setTitle(title);
 						setNoDataMessage("No actors found.", R.drawable.icon_artist_dark);
@@ -156,6 +156,7 @@ public class ActorListController extends ListController implements IController {
 				if(mVideoManager.coverLoaded(actor, mThumbSize)){
 					view.setCover(mVideoManager.getCoverSync(actor, mThumbSize));
 				}else{
+					view.setCover(null);
 					view.getResponse().load(actor, !mPostScrollLoader.isListIdle());
 				}
 			}

--- a/src/org/xbmc/android/remote/presentation/controller/ActorListController.java
+++ b/src/org/xbmc/android/remote/presentation/controller/ActorListController.java
@@ -32,6 +32,7 @@ import org.xbmc.api.business.DataResponse;
 import org.xbmc.api.business.IVideoManager;
 import org.xbmc.api.object.Actor;
 import org.xbmc.api.object.Artist;
+import org.xbmc.api.type.ThumbSize;
 
 import android.app.Activity;
 import android.content.Intent;
@@ -51,6 +52,7 @@ import android.widget.AdapterView.OnItemClickListener;
 
 public class ActorListController extends ListController implements IController {
 	
+	private static final int mThumbSize = ThumbSize.SMALL;
 	public static final int TYPE_ALL = 1;
 	public static final int TYPE_MOVIE = 2;
 	public static final int TYPE_TVSHOW = 3;
@@ -77,56 +79,42 @@ public class ActorListController extends ListController implements IController {
 				Toast toast = Toast.makeText(activity, sdError + " Displaying place holders only.", Toast.LENGTH_LONG);
 				toast.show();
 			}
+			
 			mFallbackBitmap = BitmapFactory.decodeResource(activity.getResources(), R.drawable.person_black_small);
 			setupIdleListener();
 			
-			mList.setOnKeyListener(new ListControllerOnKeyListener<Artist>());
+			final String title = mType == TYPE_MOVIE ? "Movie " : mType == TYPE_TVSHOW ? "TV " : "" + "Actors";
+			DataResponse<ArrayList<Actor>> response = new DataResponse<ArrayList<Actor>>() {
+				public void run() {
+					if (value.size() > 0) {
+						setTitle(title + " (" + value.size() + ")");
+						mList.setAdapter(new ActorAdapter(mActivity, value));
+						cacheCovers(value, mVideoManager, mThumbSize);
+					} else {
+						setTitle(title);
+						setNoDataMessage("No actors found.", R.drawable.icon_artist_dark);
+					}
+				}
+			};
+			
+			mList.setOnKeyListener(new ListControllerOnKeyListener<Artist>());			
+			
+			showOnLoading();
+			setTitle(title + "...");			
 			switch (mType) {
-			case TYPE_ALL:
-				setTitle("Actors...");
-				mVideoManager.getActors(new DataResponse<ArrayList<Actor>>() {
-					public void run() {
-						if (value.size() > 0) {
-							setTitle("Actors (" + value.size() + ")");
-							mList.setAdapter(new ActorAdapter(mActivity, value));
-						} else {
-							setTitle("Actors");
-							setNoDataMessage("No actors found.", R.drawable.icon_artist_dark);
-						}
-					}
-				}, mActivity.getApplicationContext());
-				break;
-			case TYPE_MOVIE:
-				setTitle("Movie Actors...");
-				mVideoManager.getMovieActors(new DataResponse<ArrayList<Actor>>() {
-					public void run() {
-						if (value.size() > 0) {
-							setTitle("Movie actors (" + value.size() + ")");
-							mList.setAdapter(new ActorAdapter(mActivity, value));
-						} else {
-							setTitle("Movie actors");
-							setNoDataMessage("No actors found.", R.drawable.icon_artist_dark);
-						}
-					}
-				}, mActivity.getApplicationContext());
-				break;
-			case TYPE_TVSHOW:
-				setTitle("TV Actors...");
-				mVideoManager.getTvShowActors(new DataResponse<ArrayList<Actor>>() {
-					public void run() {
-						if (value.size() > 0) {
-							setTitle("TV show actors (" + value.size() + ")");
-							mList.setAdapter(new ActorAdapter(mActivity, value));
-						} else {
-							setTitle("TV show actors");
-							setNoDataMessage("No actors found.", R.drawable.icon_artist_dark);
-						}
-					}
-				}, mActivity.getApplicationContext());
-				break;
-			case TYPE_EPISODE:
-				break;
+				case TYPE_ALL:
+					mVideoManager.getActors(response, mActivity.getApplicationContext());
+					break;
+				case TYPE_MOVIE:
+					mVideoManager.getMovieActors(response, mActivity.getApplicationContext());
+					break;
+				case TYPE_TVSHOW:
+					mVideoManager.getTvShowActors(response, mActivity.getApplicationContext());
+					break;
+				case TYPE_EPISODE:
+					break;
 			}
+			
 			mList.setOnItemClickListener(new OnItemClickListener() {
 				public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
 					if(isLoading()) return;
@@ -165,8 +153,13 @@ public class ActorListController extends ListController implements IController {
 			view.title = actor.name;
 			
 			if (mLoadCovers) {
-				view.getResponse().load(actor, !mPostScrollLoader.isListIdle());
+				if(mVideoManager.coverLoaded(actor, mThumbSize)){
+					view.setCover(mVideoManager.getCoverSync(actor, mThumbSize));
+				}else{
+					view.getResponse().load(actor, !mPostScrollLoader.isListIdle());
+				}
 			}
+
 			return view;
 		}
 	}

--- a/src/org/xbmc/android/remote/presentation/controller/AlbumListController.java
+++ b/src/org/xbmc/android/remote/presentation/controller/AlbumListController.java
@@ -220,7 +220,6 @@ public class AlbumListController extends ListController implements IController {
 				if (value.size() > 0) {
 					setTitle(title + " (" + value.size() + ")");
 					setAdapter(value);
-					preloadCovers(value, mMusicManager, mThumbSize);
 				} else {
 					setTitle(title);
 					setNoDataMessage("No albums found.", R.drawable.default_album);

--- a/src/org/xbmc/android/remote/presentation/controller/AlbumListController.java
+++ b/src/org/xbmc/android/remote/presentation/controller/AlbumListController.java
@@ -220,7 +220,7 @@ public class AlbumListController extends ListController implements IController {
 				if (value.size() > 0) {
 					setTitle(title + " (" + value.size() + ")");
 					setAdapter(value);
-					cacheCovers(value, mMusicManager, mThumbSize);
+					preloadCovers(value, mMusicManager, mThumbSize);
 				} else {
 					setTitle(title);
 					setNoDataMessage("No albums found.", R.drawable.default_album);
@@ -397,6 +397,7 @@ public class AlbumListController extends ListController implements IController {
 				if(mMusicManager.coverLoaded(album, mThumbSize)){
 					view.setCover(mMusicManager.getCoverSync(album, mThumbSize));
 				}else{
+					view.setCover(null);
 					view.getResponse().load(album, !mPostScrollLoader.isListIdle());
 				}
 			}

--- a/src/org/xbmc/android/remote/presentation/controller/AlbumListController.java
+++ b/src/org/xbmc/android/remote/presentation/controller/AlbumListController.java
@@ -38,6 +38,7 @@ import org.xbmc.api.object.Album;
 import org.xbmc.api.object.Artist;
 import org.xbmc.api.object.Genre;
 import org.xbmc.api.type.SortType;
+import org.xbmc.api.type.ThumbSize;
 
 import android.app.Activity;
 import android.app.AlertDialog;
@@ -68,6 +69,8 @@ import android.widget.AdapterView.OnItemClickListener;
  */
 public class AlbumListController extends ListController implements IController {
 	
+	private static final int mThumbSize = ThumbSize.SMALL;
+
 	private static final String TAG = "AlbumListController";
 	
 	public static final int ITEM_CONTEXT_QUEUE = 1;
@@ -211,68 +214,30 @@ public class AlbumListController extends ListController implements IController {
 	}
 	
 	private void fetch() {
-		final Artist artist = mArtist;
-		final Genre genre = mGenre;
-		if (artist != null) {						// albums of an artist
-			setTitle(artist.name + " - Albums...");
-			showOnLoading();
-			mMusicManager.getAlbums(new DataResponse<ArrayList<Album>>() {
-				public void run() {
-					if (value.size() > 0) {
-						setTitle(artist.name + " - Albums (" + value.size() + ")");
-						setAdapter(value);
-					} else {
-						setTitle(artist.name + " - Albums");
-						setNoDataMessage("No albums found.", R.drawable.default_album);
-					}
+		final String title = mArtist != null ? mArtist.name + " - " : mGenre != null ? mGenre.name + " - " : "" + (mCompilationsOnly ? "Compilations" : "Albums");
+		DataResponse<ArrayList<Album>> response = new DataResponse<ArrayList<Album>>() {
+			public void run() {
+				if (value.size() > 0) {
+					setTitle(title + " (" + value.size() + ")");
+					setAdapter(value);
+					cacheCovers(value, mMusicManager, mThumbSize);
+				} else {
+					setTitle(title);
+					setNoDataMessage("No albums found.", R.drawable.default_album);
 				}
-			}, artist, mActivity.getApplicationContext());
-			
-		} else if (genre != null) {					// albums of a genre
-			setTitle(genre.name + " - Albums...");
-			showOnLoading();
-			mMusicManager.getAlbums(new DataResponse<ArrayList<Album>>() {
-				public void run() {
-					if (value.size() > 0) {
-						setTitle(genre.name + " - Albums (" + value.size() + ")");
-						setAdapter(value);
-					} else {
-						setTitle(genre.name + " - Albums");
-						setNoDataMessage("No albums found.", R.drawable.default_album);
-					}
-				}
-			}, genre, mActivity.getApplicationContext());
-			
-		} else {
-			if (mCompilationsOnly) {				// compilations
-				setTitle("Compilations...");
-				showOnLoading();
-				mMusicManager.getCompilations(new DataResponse<ArrayList<Album>>() {
-					public void run() {
-						if (value.size() > 0) {
-							setTitle("Compilations (" + value.size() + ")");
-							setAdapter(value);
-						} else {
-							setTitle("Compilations");
-							setNoDataMessage("No compilations found.", R.drawable.default_album);
-						}
-					}
-				}, mActivity.getApplicationContext());
-			} else {
-				setTitle("Albums...");				// all albums
-				showOnLoading();
-				mMusicManager.getAlbums(new DataResponse<ArrayList<Album>>() {
-					public void run() {
-						if (value.size() > 0) {
-							setTitle("Albums (" + value.size() + ")");
-							setAdapter(value);
-						} else {
-							setTitle("Albums");
-							setNoDataMessage("No Albums found.", R.drawable.default_album);
-						}
-					}
-				}, mActivity.getApplicationContext());
 			}
+		};
+		
+		showOnLoading();
+		setTitle(title + "...");		
+		if (mArtist != null) {						// albums of an artist
+			mMusicManager.getAlbums(response, mArtist, mActivity.getApplicationContext());			
+		} else if (mGenre != null) {				// albums of a genre
+			mMusicManager.getAlbums(response, mGenre, mActivity.getApplicationContext());			
+		} else if (mCompilationsOnly) {				// compilations
+			mMusicManager.getCompilations(response, mActivity.getApplicationContext());
+		} else {
+			mMusicManager.getAlbums(response, mActivity.getApplicationContext());
 		}
 	}
 	
@@ -429,7 +394,11 @@ public class AlbumListController extends ListController implements IController {
 			view.subsubtitle = album.year > 0 ? String.valueOf(album.year) : "";
 			Log.i(TAG, "isListIdle: " + mPostScrollLoader.isListIdle());
 			if (mLoadCovers) {
-				view.getResponse().load(album, !mPostScrollLoader.isListIdle());
+				if(mMusicManager.coverLoaded(album, mThumbSize)){
+					view.setCover(mMusicManager.getCoverSync(album, mThumbSize));
+				}else{
+					view.getResponse().load(album, !mPostScrollLoader.isListIdle());
+				}
 			}
 			return view;
 		}

--- a/src/org/xbmc/android/remote/presentation/controller/ArtistListController.java
+++ b/src/org/xbmc/android/remote/presentation/controller/ArtistListController.java
@@ -104,7 +104,6 @@ public class ArtistListController extends ListController implements IController 
 					if (value.size() > 0) {
 						setTitle(title + " (" + value.size() + ")");
 						mList.setAdapter(new ArtistAdapter(mActivity, value));
-						preloadCovers(value, mMusicManager, mThumbSize);
 					} else {
 						setTitle(title);
 						setNoDataMessage("No artists found.", R.drawable.icon_artist_dark);

--- a/src/org/xbmc/android/remote/presentation/controller/ArtistListController.java
+++ b/src/org/xbmc/android/remote/presentation/controller/ArtistListController.java
@@ -33,6 +33,7 @@ import org.xbmc.api.business.DataResponse;
 import org.xbmc.api.business.IMusicManager;
 import org.xbmc.api.object.Artist;
 import org.xbmc.api.object.Genre;
+import org.xbmc.api.type.ThumbSize;
 
 import android.app.Activity;
 import android.content.Intent;
@@ -53,6 +54,7 @@ import android.widget.AdapterView.OnItemClickListener;
 
 public class ArtistListController extends ListController implements IController {
 	
+	private static final int mThumbSize = ThumbSize.SMALL;
 	public static final int ITEM_CONTEXT_QUEUE = 1;
 	public static final int ITEM_CONTEXT_PLAY = 2;
 	public static final int ITEM_CONTEXT_QUEUE_GENRE = 3;
@@ -95,37 +97,29 @@ public class ArtistListController extends ListController implements IController 
 					mActivity.startActivity(nextActivity);
 				}
 			});
+					
+			final String title = mGenre != null ? mGenre.name + " - " : "" + "Artists";
+			DataResponse<ArrayList<Artist>> response = new DataResponse<ArrayList<Artist>>() {
+				public void run() {
+					if (value.size() > 0) {
+						setTitle(title + " (" + value.size() + ")");
+						mList.setAdapter(new ArtistAdapter(mActivity, value));
+						cacheCovers(value, mMusicManager, mThumbSize);
+					} else {
+						setTitle(title);
+						setNoDataMessage("No artists found.", R.drawable.icon_artist_dark);
+					}
+				}
+			};
+
+			mList.setOnKeyListener(new ListControllerOnKeyListener<Artist>());	
 			
-			mList.setOnKeyListener(new ListControllerOnKeyListener<Artist>());			
-			
+			showOnLoading();
+			setTitle(title + "...");			
 			if (mGenre != null) {
-				setTitle(mGenre.name + " - Artists...");
-				showOnLoading();
-				mMusicManager.getArtists(new DataResponse<ArrayList<Artist>>() {
-					public void run() {
-						if (value.size() > 0) {
-							setTitle(mGenre.name + " - Artists (" + value.size() + ")");
-							mList.setAdapter(new ArtistAdapter(mActivity, value));
-						} else {
-							setTitle(mGenre.name + " - Artists");
-							setNoDataMessage("No artists found.", R.drawable.icon_artist_dark);
-						}
-					}
-				}, mGenre, mActivity.getApplicationContext());
+				mMusicManager.getArtists(response, mGenre, mActivity.getApplicationContext());
 			} else {
-				setTitle("Artists...");
-				showOnLoading();
-				mMusicManager.getArtists(new DataResponse<ArrayList<Artist>>() {
-					public void run() {
-						if (value.size() > 0) {
-							setTitle("Artists (" + value.size() + ")");
-							mList.setAdapter(new ArtistAdapter(mActivity, value));
-						} else {
-							setTitle("Artists");
-							setNoDataMessage("No artists found.", R.drawable.icon_artist_dark);
-						}
-					}
-				}, mActivity.getApplicationContext());
+				mMusicManager.getArtists(response, mActivity.getApplicationContext());
 			}
 		}
 	}
@@ -209,6 +203,14 @@ public class ArtistListController extends ListController implements IController 
 			if (mLoadCovers) {
 				view.getResponse().load(artist, !mPostScrollLoader.isListIdle());
 			}
+			if (mLoadCovers) {
+				if(mMusicManager.coverLoaded(artist, mThumbSize)){
+					view.setCover(mMusicManager.getCoverSync(artist, mThumbSize));
+				}else{
+					view.getResponse().load(artist, !mPostScrollLoader.isListIdle());
+				}
+			}
+
 			return view;
 		}
 	}

--- a/src/org/xbmc/android/remote/presentation/controller/ArtistListController.java
+++ b/src/org/xbmc/android/remote/presentation/controller/ArtistListController.java
@@ -104,7 +104,7 @@ public class ArtistListController extends ListController implements IController 
 					if (value.size() > 0) {
 						setTitle(title + " (" + value.size() + ")");
 						mList.setAdapter(new ArtistAdapter(mActivity, value));
-						cacheCovers(value, mMusicManager, mThumbSize);
+						preloadCovers(value, mMusicManager, mThumbSize);
 					} else {
 						setTitle(title);
 						setNoDataMessage("No artists found.", R.drawable.icon_artist_dark);
@@ -207,6 +207,7 @@ public class ArtistListController extends ListController implements IController 
 				if(mMusicManager.coverLoaded(artist, mThumbSize)){
 					view.setCover(mMusicManager.getCoverSync(artist, mThumbSize));
 				}else{
+					view.setCover(null);
 					view.getResponse().load(artist, !mPostScrollLoader.isListIdle());
 				}
 			}

--- a/src/org/xbmc/android/remote/presentation/controller/EpisodeListController.java
+++ b/src/org/xbmc/android/remote/presentation/controller/EpisodeListController.java
@@ -139,7 +139,7 @@ public class EpisodeListController extends ListController implements IController
 				if (value.size() > 0) {
 					setTitle(title + " (" + value.size() + ")");
 					mList.setAdapter(new EpisodeAdapter(mActivity, value));
-					cacheCovers(value, mTvManager, mThumbSize);
+					preloadCovers(value, mTvManager, mThumbSize);
 				} else {
 					setNoDataMessage("No episodes found.", R.drawable.icon_movie_dark);
 				}
@@ -317,6 +317,7 @@ public class EpisodeListController extends ListController implements IController
 				if(mTvManager.coverLoaded(episode, mThumbSize)){
 					view.setCover(mTvManager.getCoverSync(episode, mThumbSize));
 				}else{
+					view.setCover(null);
 					view.getResponse().load(episode, !mPostScrollLoader.isListIdle());
 				}
 			}

--- a/src/org/xbmc/android/remote/presentation/controller/EpisodeListController.java
+++ b/src/org/xbmc/android/remote/presentation/controller/EpisodeListController.java
@@ -139,7 +139,6 @@ public class EpisodeListController extends ListController implements IController
 				if (value.size() > 0) {
 					setTitle(title + " (" + value.size() + ")");
 					mList.setAdapter(new EpisodeAdapter(mActivity, value));
-					preloadCovers(value, mTvManager, mThumbSize);
 				} else {
 					setNoDataMessage("No episodes found.", R.drawable.icon_movie_dark);
 				}

--- a/src/org/xbmc/android/remote/presentation/controller/EpisodeListController.java
+++ b/src/org/xbmc/android/remote/presentation/controller/EpisodeListController.java
@@ -39,6 +39,7 @@ import org.xbmc.api.object.Episode;
 import org.xbmc.api.object.Movie;
 import org.xbmc.api.object.Season;
 import org.xbmc.api.type.SortType;
+import org.xbmc.api.type.ThumbSize;
 
 import android.app.Activity;
 import android.app.AlertDialog;
@@ -65,6 +66,7 @@ import android.widget.AdapterView.OnItemClickListener;
 
 public class EpisodeListController extends ListController implements IController {
 	
+	private static final int mThumbSize = ThumbSize.SMALL;
 	public static final int ITEM_CONTEXT_PLAY = 1;
 	public static final int ITEM_CONTEXT_INFO = 2;
 	
@@ -126,26 +128,28 @@ public class EpisodeListController extends ListController implements IController
 		}
 	}
 	
-	private void fetch() {
-		final Season season = mSeason;
-		
+	private void fetch() {		
 		// tv show and episode both are using the same manager so set the sort key here
 		((ISortableManager)mTvManager).setSortKey(AbstractManager.PREF_SORT_KEY_EPISODE);
 		((ISortableManager)mTvManager).setPreferences(mActivity.getPreferences(Context.MODE_PRIVATE));
 		
-		showOnLoading();
-		if (season != null) {
-			setTitle(season.getName() + " - Episodes");
-			mTvManager.getEpisodes(new DataResponse<ArrayList<Episode>>() {
-				public void run() {
-					if (value.size() > 0) {
-						setTitle(season.getName() + " - Episodes (" + value.size() + ")");
-						mList.setAdapter(new EpisodeAdapter(mActivity, value));
-					} else {
-						setNoDataMessage("No episodes found.", R.drawable.icon_movie_dark);
-					}
+		final String title = mSeason != null ? mSeason.getName() + " - " : "" + "Episodes";
+		DataResponse<ArrayList<Episode>> response = new DataResponse<ArrayList<Episode>>() {
+			public void run() {
+				if (value.size() > 0) {
+					setTitle(title + " (" + value.size() + ")");
+					mList.setAdapter(new EpisodeAdapter(mActivity, value));
+					cacheCovers(value, mTvManager, mThumbSize);
+				} else {
+					setNoDataMessage("No episodes found.", R.drawable.icon_movie_dark);
 				}
-			}, season, mActivity.getApplicationContext());
+			}
+		};
+		
+		showOnLoading();
+		setTitle(title + "...");
+		if (mSeason != null) {
+			mTvManager.getEpisodes(response, mSeason, mActivity.getApplicationContext());
 		}
 	}
 	
@@ -310,7 +314,11 @@ public class EpisodeListController extends ListController implements IController
 			view.bottomright = String.valueOf(((float)Math.round(episode.rating *10))/ 10);
 			
 			if (mLoadCovers) {
-				view.getResponse().load(episode, !mPostScrollLoader.isListIdle());
+				if(mTvManager.coverLoaded(episode, mThumbSize)){
+					view.setCover(mTvManager.getCoverSync(episode, mThumbSize));
+				}else{
+					view.getResponse().load(episode, !mPostScrollLoader.isListIdle());
+				}
 			}
 			return view;
 		}

--- a/src/org/xbmc/android/remote/presentation/controller/EpisodeListController.java
+++ b/src/org/xbmc/android/remote/presentation/controller/EpisodeListController.java
@@ -135,11 +135,11 @@ public class EpisodeListController extends ListController implements IController
 		
 		showOnLoading();
 		if (season != null) {
-			setTitle(season.show.title + " Season " + season.number + " - Episodes");
+			setTitle(season.getName() + " - Episodes");
 			mTvManager.getEpisodes(new DataResponse<ArrayList<Episode>>() {
 				public void run() {
-					if(value.size() > 0) {
-						setTitle(season.show.title + " Season " + season.number + " - Episodes (" + value.size() + ")");
+					if (value.size() > 0) {
+						setTitle(season.getName() + " - Episodes (" + value.size() + ")");
 						mList.setAdapter(new EpisodeAdapter(mActivity, value));
 					} else {
 						setNoDataMessage("No episodes found.", R.drawable.icon_movie_dark);

--- a/src/org/xbmc/android/remote/presentation/controller/ListController.java
+++ b/src/org/xbmc/android/remote/presentation/controller/ListController.java
@@ -22,13 +22,18 @@
 package org.xbmc.android.remote.presentation.controller;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 
 import org.xbmc.android.remote.R;
 import org.xbmc.android.remote.presentation.activity.NowPlayingActivity;
+import org.xbmc.android.remote.presentation.widget.AbstractItemView;
 import org.xbmc.android.widget.FastScrollView;
 import org.xbmc.android.widget.IdleListDetector;
 import org.xbmc.android.widget.IdleListener;
+import org.xbmc.api.business.CoverResponse;
 import org.xbmc.api.business.DataResponse;
+import org.xbmc.api.business.IManager;
+import org.xbmc.api.object.ICoverArt;
 import org.xbmc.api.presentation.INotifiableController;
 import org.xbmc.api.type.ThumbSize;
 
@@ -38,6 +43,7 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.graphics.Bitmap;
 import android.os.Handler;
+import android.util.Log;
 import android.view.ContextMenu;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -155,6 +161,20 @@ public abstract class ListController extends AbstractController implements Seria
 				}
 			});
 		}
+	}
+	
+	protected <T extends ICoverArt> void cacheCovers(final ArrayList<T> list, final IManager manager, final int thumbSize)
+	{
+		// Use the managers message queue to download the data, don't want to tie up the UI message queue
+		manager.post(new Runnable() {
+			public void run()
+			{
+				for(ICoverArt cover : list) {
+					CoverResponse response = new CoverResponse(null, manager, null, thumbSize, null);
+					response.load(cover, thumbSize, false);
+				}
+			}
+		});
 	}
 	
 	protected boolean isCreated() {

--- a/src/org/xbmc/android/remote/presentation/controller/ListController.java
+++ b/src/org/xbmc/android/remote/presentation/controller/ListController.java
@@ -26,7 +26,6 @@ import java.util.ArrayList;
 
 import org.xbmc.android.remote.R;
 import org.xbmc.android.remote.presentation.activity.NowPlayingActivity;
-import org.xbmc.android.remote.presentation.widget.AbstractItemView;
 import org.xbmc.android.widget.FastScrollView;
 import org.xbmc.android.widget.IdleListDetector;
 import org.xbmc.android.widget.IdleListener;
@@ -43,7 +42,6 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.graphics.Bitmap;
 import android.os.Handler;
-import android.util.Log;
 import android.view.ContextMenu;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -163,7 +161,7 @@ public abstract class ListController extends AbstractController implements Seria
 		}
 	}
 	
-	protected <T extends ICoverArt> void cacheCovers(final ArrayList<T> list, final IManager manager, final int thumbSize)
+	protected <T extends ICoverArt> void preloadCovers(final ArrayList<T> list, final IManager manager, final int thumbSize)
 	{
 		// Use the managers message queue to download the data, don't want to tie up the UI message queue
 		manager.post(new Runnable() {
@@ -171,7 +169,7 @@ public abstract class ListController extends AbstractController implements Seria
 			{
 				for(ICoverArt cover : list) {
 					CoverResponse response = new CoverResponse(null, manager, null, thumbSize, null);
-					response.load(cover, thumbSize, false);
+					response.load(cover, thumbSize, true);
 				}
 			}
 		});

--- a/src/org/xbmc/android/remote/presentation/controller/ListController.java
+++ b/src/org/xbmc/android/remote/presentation/controller/ListController.java
@@ -22,17 +22,13 @@
 package org.xbmc.android.remote.presentation.controller;
 
 import java.io.Serializable;
-import java.util.ArrayList;
 
 import org.xbmc.android.remote.R;
 import org.xbmc.android.remote.presentation.activity.NowPlayingActivity;
 import org.xbmc.android.widget.FastScrollView;
 import org.xbmc.android.widget.IdleListDetector;
 import org.xbmc.android.widget.IdleListener;
-import org.xbmc.api.business.CoverResponse;
 import org.xbmc.api.business.DataResponse;
-import org.xbmc.api.business.IManager;
-import org.xbmc.api.object.ICoverArt;
 import org.xbmc.api.presentation.INotifiableController;
 import org.xbmc.api.type.ThumbSize;
 
@@ -160,21 +156,7 @@ public abstract class ListController extends AbstractController implements Seria
 			});
 		}
 	}
-	
-	protected <T extends ICoverArt> void preloadCovers(final ArrayList<T> list, final IManager manager, final int thumbSize)
-	{
-		// Use the managers message queue to download the data, don't want to tie up the UI message queue
-		manager.post(new Runnable() {
-			public void run()
-			{
-				for(ICoverArt cover : list) {
-					CoverResponse response = new CoverResponse(null, manager, null, thumbSize, null);
-					response.load(cover, thumbSize, true);
-				}
-			}
-		});
-	}
-	
+		
 	protected boolean isCreated() {
 		return isCreated;
 	}

--- a/src/org/xbmc/android/remote/presentation/controller/MovieGenreListController.java
+++ b/src/org/xbmc/android/remote/presentation/controller/MovieGenreListController.java
@@ -77,39 +77,34 @@ public class MovieGenreListController extends ListController implements IControl
 					mActivity.startActivity(nextActivity);
 				}
 			});
+			
 			mFallbackBitmap = BitmapFactory.decodeResource(activity.getResources(), R.drawable.icon_genre);
-			setTitle("Movie genres...");
+			
+			final String title = mType == TYPE_MOVIE ? "Movie " : mType == TYPE_TVSHOW ? "TV Show " : "" + "genres";
+			DataResponse<ArrayList<Genre>> response = new DataResponse<ArrayList<Genre>>() {
+				public void run() {
+					if (value.size() > 0) {
+						setTitle(title + " (" + value.size() + ")");
+						mList.setAdapter(new GenreAdapter(mActivity, value));
+					} else {
+						setTitle(title);
+						setNoDataMessage("No genres found.", R.drawable.icon_genre_dark);
+					}
+				}
+			};
+
+			mList.setOnKeyListener(new ListControllerOnKeyListener<Genre>());
+			
 			showOnLoading();
+			setTitle(title + "...");			
 			switch(mType) {
 			case TYPE_MOVIE:
-				mVideoManager.getMovieGenres(new DataResponse<ArrayList<Genre>>() {
-					public void run() {
-						if (value.size() > 0) {
-							setTitle("Movie genres (" + value.size() + ")");
-							mList.setAdapter(new GenreAdapter(mActivity, value));
-						} else {
-							setTitle("Movie genres");
-							setNoDataMessage("No genres found.", R.drawable.icon_genre_dark);
-						}
-					}
-				}, mActivity.getApplicationContext());
+				mVideoManager.getMovieGenres(response, mActivity.getApplicationContext());
 				break;
 			case TYPE_TVSHOW:
-				mVideoManager.getTvShowGenres(new DataResponse<ArrayList<Genre>>() {
-					public void run() {
-						if (value.size() > 0) {
-							setTitle("Tv Show genres (" + value.size() + ")");
-							mList.setAdapter(new GenreAdapter(mActivity, value));
-						} else {
-							setTitle("Tv Show genres");
-							setNoDataMessage("No genres found.", R.drawable.icon_genre_dark);
-						}
-					}
-				}, mActivity.getApplicationContext());
+				mVideoManager.getTvShowGenres(response, mActivity.getApplicationContext());
 				break;
-			}
-			
-			mList.setOnKeyListener(new ListControllerOnKeyListener<Genre>());
+			}			
 		}
 	}
 	

--- a/src/org/xbmc/android/remote/presentation/controller/MovieListController.java
+++ b/src/org/xbmc/android/remote/presentation/controller/MovieListController.java
@@ -139,7 +139,6 @@ public class MovieListController extends ListController implements IController {
 				if (value.size() > 0) {
 					setTitle(title + " (" + value.size() + ")");
 					mList.setAdapter(new MovieAdapter(mActivity, value));
-					preloadCovers(value, mVideoManager, mThumbSize);
 				} else {
 					setTitle(title);
 					setNoDataMessage("No movies found.", R.drawable.icon_movie_dark);

--- a/src/org/xbmc/android/remote/presentation/controller/MovieListController.java
+++ b/src/org/xbmc/android/remote/presentation/controller/MovieListController.java
@@ -38,6 +38,7 @@ import org.xbmc.api.object.Actor;
 import org.xbmc.api.object.Genre;
 import org.xbmc.api.object.Movie;
 import org.xbmc.api.type.SortType;
+import org.xbmc.api.type.ThumbSize;
 
 import android.app.Activity;
 import android.app.AlertDialog;
@@ -63,7 +64,8 @@ import android.widget.AdapterView.AdapterContextMenuInfo;
 import android.widget.AdapterView.OnItemClickListener;
 
 public class MovieListController extends ListController implements IController {
-	
+
+	private static final int mThumbSize = ThumbSize.SMALL;
 	public static final int ITEM_CONTEXT_PLAY = 1;
 	public static final int ITEM_CONTEXT_INFO = 2;
 	
@@ -131,49 +133,28 @@ public class MovieListController extends ListController implements IController {
 	}
 	
 	private void fetch() {
-		final Actor actor = mActor;
-		final Genre genre = mGenre;
+		final String title = mActor != null ? mActor.name + " - " : mGenre != null ? mGenre.name + " - " : "" + "Movies";
+		DataResponse<ArrayList<Movie>> response = new DataResponse<ArrayList<Movie>>() {
+			public void run() {
+				if (value.size() > 0) {
+					setTitle(title + " (" + value.size() + ")");
+					mList.setAdapter(new MovieAdapter(mActivity, value));
+					cacheCovers(value, mVideoManager, mThumbSize);
+				} else {
+					setTitle(title);
+					setNoDataMessage("No movies found.", R.drawable.icon_movie_dark);
+				}
+			}
+		};
+		
 		showOnLoading();
-		if (actor != null) {						// movies with a certain actor
-			setTitle(actor.name + " - Movies...");
-			mVideoManager.getMovies(new DataResponse<ArrayList<Movie>>() {
-				public void run() {
-					if (value.size() > 0) {
-						setTitle(actor.name + " - Movies (" + value.size() + ")");
-						mList.setAdapter(new MovieAdapter(mActivity, value));
-					} else {
-						setTitle(actor.name + " - Movies");
-						setNoDataMessage("No movies found.", R.drawable.icon_movie_dark);
-					}
-				}
-			}, actor, mActivity.getApplicationContext());
-			
-		} else if (genre != null) {					// movies of a genre
-			setTitle(genre.name + " - Movies...");
-			mVideoManager.getMovies(new DataResponse<ArrayList<Movie>>() {
-				public void run() {
-					if (value.size() > 0) {
-						setTitle(genre.name + " - Movies (" + value.size() + ")");
-						mList.setAdapter(new MovieAdapter(mActivity, value));
-					} else {
-						setTitle(genre.name + " - Movies");
-						setNoDataMessage("No movies found.", R.drawable.icon_movie_dark);
-					}
-				}
-			}, genre, mActivity.getApplicationContext());
-		} else {
-			setTitle("Movies...");				// all movies
-			mVideoManager.getMovies(new DataResponse<ArrayList<Movie>>() {
-				public void run() {
-					if (value.size() > 0) {
-						setTitle("Movies (" + value.size() + ")");
-						mList.setAdapter(new MovieAdapter(mActivity, value));
-					} else {
-						setTitle("Movies");
-						setNoDataMessage("No movies found.", R.drawable.icon_movie_dark);
-					}
-				}
-			}, mActivity.getApplicationContext());
+		setTitle(title + "...");
+		if (mActor != null) {						// movies with a certain actor
+			mVideoManager.getMovies(response, mActor, mActivity.getApplicationContext());
+		} else if (mGenre != null) {					// movies of a genre
+			mVideoManager.getMovies(response, mGenre, mActivity.getApplicationContext());
+		} else {									// all movies
+			mVideoManager.getMovies(response, mActivity.getApplicationContext());
 		}
 	}
 	
@@ -354,7 +335,11 @@ public class MovieListController extends ListController implements IController {
 			view.bottomright = String.valueOf(movie.rating);
 			
 			if (mLoadCovers) {
-				view.getResponse().load(movie, !mPostScrollLoader.isListIdle());
+				if(mVideoManager.coverLoaded(movie, mThumbSize)){
+					view.setCover(mVideoManager.getCoverSync(movie, mThumbSize));
+				}else{
+					view.getResponse().load(movie, !mPostScrollLoader.isListIdle());
+				}
 			}
 			return view;
 		}

--- a/src/org/xbmc/android/remote/presentation/controller/MovieListController.java
+++ b/src/org/xbmc/android/remote/presentation/controller/MovieListController.java
@@ -139,7 +139,7 @@ public class MovieListController extends ListController implements IController {
 				if (value.size() > 0) {
 					setTitle(title + " (" + value.size() + ")");
 					mList.setAdapter(new MovieAdapter(mActivity, value));
-					cacheCovers(value, mVideoManager, mThumbSize);
+					preloadCovers(value, mVideoManager, mThumbSize);
 				} else {
 					setTitle(title);
 					setNoDataMessage("No movies found.", R.drawable.icon_movie_dark);
@@ -338,6 +338,7 @@ public class MovieListController extends ListController implements IController {
 				if(mVideoManager.coverLoaded(movie, mThumbSize)){
 					view.setCover(mVideoManager.getCoverSync(movie, mThumbSize));
 				}else{
+					view.setCover(null);
 					view.getResponse().load(movie, !mPostScrollLoader.isListIdle());
 				}
 			}

--- a/src/org/xbmc/android/remote/presentation/controller/MusicGenreListController.java
+++ b/src/org/xbmc/android/remote/presentation/controller/MusicGenreListController.java
@@ -72,22 +72,27 @@ public class MusicGenreListController extends ListController implements IControl
 					mActivity.startActivity(nextActivity);
 				}
 			});
+			
 			mFallbackBitmap = BitmapFactory.decodeResource(activity.getResources(), R.drawable.icon_genre);
-			setTitle("Genres...");
-			showOnLoading();
-			mMusicManager.getGenres(new DataResponse<ArrayList<Genre>>() {
+			
+			final String title = "Genres";
+			DataResponse<ArrayList<Genre>> response = new DataResponse<ArrayList<Genre>>() {
 				public void run() {
 					if (value.size() > 0) {
-						setTitle("Genres (" + value.size() + ")");
+						setTitle(title + " (" + value.size() + ")");
 						mList.setAdapter(new GenreAdapter(mActivity, value));
 					} else {
-						setTitle("Genres");
+						setTitle(title);
 						setNoDataMessage("No genres found.", R.drawable.icon_genre_dark);
 					}
 				}
-			}, mActivity.getApplicationContext());
+			};
 			
 			mList.setOnKeyListener(new ListControllerOnKeyListener<Genre>());
+
+			setTitle("...");
+			showOnLoading();
+			mMusicManager.getGenres(response, mActivity.getApplicationContext());			
 		}
 	}
 	

--- a/src/org/xbmc/android/remote/presentation/controller/SeasonListController.java
+++ b/src/org/xbmc/android/remote/presentation/controller/SeasonListController.java
@@ -124,7 +124,7 @@ public class SeasonListController extends ListController implements IController 
 				if (value.size() > 0) {
 					setTitle(title +" (" + value.size() + ")");
 					mList.setAdapter(new SeasonAdapter(mActivity, value));
-					cacheCovers(value, mTvManager, mThumbSize);
+					preloadCovers(value, mTvManager, mThumbSize);
 				} else {
 					setTitle(title);
 					setNoDataMessage("No seasons found.", R.drawable.icon_movie_dark);
@@ -275,6 +275,7 @@ public class SeasonListController extends ListController implements IController 
 				if (mTvManager.coverLoaded(season, mThumbSize)) {
 					view.setCover(mTvManager.getCoverSync(season, mThumbSize));
 				} else {
+					view.setCover(null);
 					view.getResponse().load(season, mThumbSize, !mPostScrollLoader.isListIdle());
 				}
 			}

--- a/src/org/xbmc/android/remote/presentation/controller/SeasonListController.java
+++ b/src/org/xbmc/android/remote/presentation/controller/SeasonListController.java
@@ -57,9 +57,9 @@ import android.widget.AdapterView.AdapterContextMenuInfo;
 import android.widget.AdapterView.OnItemClickListener;
 
 public class SeasonListController extends ListController implements IController {
-	
+
 	public static final int ITEM_CONTEXT_BROWSE = 1;
-	
+
 	public static final int MENU_PLAY_ALL = 1;
 	public static final int MENU_SORT = 2;
 	public static final int MENU_SORT_BY_TITLE_ASC = 21;
@@ -68,44 +68,52 @@ public class SeasonListController extends ListController implements IController 
 	public static final int MENU_SORT_BY_YEAR_DESC = 24;
 	public static final int MENU_SORT_BY_RATING_ASC = 25;
 	public static final int MENU_SORT_BY_RATING_DESC = 26;
-	
+
 	private TvShow mShow;
-	
+
 	private ITvShowManager mTvManager;
 	private IControlManager mControlManager;
-	
+
 	private boolean mLoadCovers = false;
-	
+
 	public void onCreate(Activity activity, Handler handler, AbsListView list) {
-		
+
 		mTvManager = ManagerFactory.getTvManager(this);
 		mControlManager = ManagerFactory.getControlManager(this);
-		
+
 		final String sdError = ImportUtilities.assertSdCard();
 		mLoadCovers = sdError == null;
-		
+
 		if (!isCreated()) {
 			super.onCreate(activity, handler, list);
 
 			if (!mLoadCovers) {
-				Toast toast = Toast.makeText(activity, sdError + " Displaying place holders only.", Toast.LENGTH_LONG);
+				Toast toast = Toast.makeText(activity, sdError
+						+ " Displaying place holders only.", Toast.LENGTH_LONG);
 				toast.show();
 			}
-			
-			mShow = (TvShow)activity.getIntent().getSerializableExtra(ListController.EXTRA_TVSHOW);
-			
+
+			mShow = (TvShow) activity.getIntent().getSerializableExtra(
+					ListController.EXTRA_TVSHOW);
+
 			activity.registerForContextMenu(mList);
-			
-			mFallbackBitmap = BitmapFactory.decodeResource(activity.getResources(), R.drawable.default_season);
+
+			mFallbackBitmap = BitmapFactory.decodeResource(
+					activity.getResources(), R.drawable.default_season);
 			setupIdleListener(ThumbSize.MEDIUM);
-			
+
 			mList.setOnItemClickListener(new OnItemClickListener() {
-				public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
-					if(isLoading()) return;
-					final Season season = (Season)mList.getAdapter().getItem(((GridPosterItemView)view).position);
-					Intent nextActivity = new Intent(view.getContext(), ListActivity.class);
+				public void onItemClick(AdapterView<?> parent, View view,
+						int position, long id) {
+					if (isLoading())
+						return;
+					final Season season = (Season) mList.getAdapter().getItem(
+							((GridPosterItemView) view).position);
+					Intent nextActivity = new Intent(view.getContext(),
+							ListActivity.class);
 					nextActivity.putExtra(ListController.EXTRA_SEASON, season);
-					nextActivity.putExtra(ListController.EXTRA_LIST_CONTROLLER, new EpisodeListController());
+					nextActivity.putExtra(ListController.EXTRA_LIST_CONTROLLER,
+							new EpisodeListController());
 					mActivity.startActivity(nextActivity);
 				}
 			});
@@ -113,7 +121,7 @@ public class SeasonListController extends ListController implements IController 
 			fetch();
 		}
 	}
-	
+
 	private void fetch() {
 		final TvShow show = mShow;
 		showOnLoading();
@@ -121,90 +129,110 @@ public class SeasonListController extends ListController implements IController 
 			setTitle(show.title + " - Seasons");
 			mTvManager.getSeasons(new DataResponse<ArrayList<Season>>() {
 				public void run() {
-					if(value.size() > 0) {
-						setTitle(show.title + " - Seasons (" + value.size() + ")");
+					if (value.size() > 0) {
+						setTitle(show.title + " - Seasons (" + value.size()
+								+ ")");
 						mList.setAdapter(new SeasonAdapter(mActivity, value));
 					} else {
-						setNoDataMessage("No seasons found.", R.drawable.icon_movie_dark);
+						setNoDataMessage("No seasons found.",
+								R.drawable.icon_movie_dark);
 					}
 				}
 			}, show, mActivity.getApplicationContext());
 		}
 	}
-	
+
 	/**
 	 * Shows a dialog and refreshes the movie library if user confirmed.
+	 * 
 	 * @param activity
 	 */
 	public void refreshMovieLibrary(final Activity activity) {
 		final AlertDialog.Builder builder = new AlertDialog.Builder(activity);
-		builder.setMessage("Are you sure you want XBMC to rescan your movie library?")
-			.setCancelable(false)
-			.setPositiveButton("Yes!", new DialogInterface.OnClickListener() {
-				public void onClick(DialogInterface dialog, int which) {
-					mControlManager.updateLibrary(new DataResponse<Boolean>() {
-						public void run() {
-							final String message;
-							if (value) {
-								message = "Movie library updated has been launched.";
-							} else {
-								message = "Error launching movie library update.";
+		builder.setMessage(
+				"Are you sure you want XBMC to rescan your movie library?")
+				.setCancelable(false)
+				.setPositiveButton("Yes!",
+						new DialogInterface.OnClickListener() {
+							public void onClick(DialogInterface dialog,
+									int which) {
+								mControlManager.updateLibrary(
+										new DataResponse<Boolean>() {
+											public void run() {
+												final String message;
+												if (value) {
+													message = "Movie library updated has been launched.";
+												} else {
+													message = "Error launching movie library update.";
+												}
+												Toast toast = Toast.makeText(
+														activity, message,
+														Toast.LENGTH_SHORT);
+												toast.show();
+											}
+										}, "video", mActivity
+												.getApplicationContext());
 							}
-							Toast toast = Toast.makeText(activity, message, Toast.LENGTH_SHORT);
-							toast.show();
-						}
-					}, "video", mActivity.getApplicationContext());
-				}
-			})
-			.setNegativeButton("Uh, no.", new DialogInterface.OnClickListener() {
-				public void onClick(DialogInterface dialog, int which) {
-					dialog.cancel();
-				}
-			});
+						})
+				.setNegativeButton("Uh, no.",
+						new DialogInterface.OnClickListener() {
+							public void onClick(DialogInterface dialog,
+									int which) {
+								dialog.cancel();
+							}
+						});
 		builder.create().show();
 	}
-	
+
 	@Override
-	public void onCreateContextMenu(ContextMenu menu, View v, ContextMenuInfo menuInfo) {
-		final GridPosterItemView view = (GridPosterItemView)((AdapterContextMenuInfo)menuInfo).targetView;
+	public void onCreateContextMenu(ContextMenu menu, View v,
+			ContextMenuInfo menuInfo) {
+		final GridPosterItemView view = (GridPosterItemView) ((AdapterContextMenuInfo) menuInfo).targetView;
 		menu.setHeaderTitle(view.title);
 		menu.add(0, ITEM_CONTEXT_BROWSE, 1, "Browse Season");
 	}
-	
+
 	public void onContextItemSelected(MenuItem item) {
-		//final Season season = (Season)mList.getAdapter().getItem(((GridPosterItemView)view).position);
-		final Season season = (Season)mList.getAdapter().getItem(((GridPosterItemView)((AdapterContextMenuInfo)item.getMenuInfo()).targetView).position);
+		// final Season season =
+		// (Season)mList.getAdapter().getItem(((GridPosterItemView)view).position);
+		final Season season = (Season) mList.getAdapter().getItem(
+				((GridPosterItemView) ((AdapterContextMenuInfo) item
+						.getMenuInfo()).targetView).position);
 		switch (item.getItemId()) {
-			case ITEM_CONTEXT_BROWSE:
-				Intent nextActivity = new Intent(mActivity, ListActivity.class);
-				nextActivity.putExtra(ListController.EXTRA_SEASON, season);
-				nextActivity.putExtra(ListController.EXTRA_LIST_CONTROLLER, new EpisodeListController());
-				mActivity.startActivity(nextActivity);
-				break;
-			default:
-				return;
+		case ITEM_CONTEXT_BROWSE:
+			Intent nextActivity = new Intent(mActivity, ListActivity.class);
+			nextActivity.putExtra(ListController.EXTRA_SEASON, season);
+			nextActivity.putExtra(ListController.EXTRA_LIST_CONTROLLER,
+					new EpisodeListController());
+			mActivity.startActivity(nextActivity);
+			break;
+		default:
+			return;
 		}
 	}
-	
+
 	@Override
 	public void onCreateOptionsMenu(Menu menu) {
-//		if (mActor != null || mGenre != null) {
-//			menu.add(0, MENU_PLAY_ALL, 0, "Play all").setIcon(R.drawable.menu_album);
-//		}
-		SubMenu sortMenu = menu.addSubMenu(0, MENU_SORT, 0, "Sort").setIcon(R.drawable.menu_sort);
+		// if (mActor != null || mGenre != null) {
+		// menu.add(0, MENU_PLAY_ALL, 0,
+		// "Play all").setIcon(R.drawable.menu_album);
+		// }
+		SubMenu sortMenu = menu.addSubMenu(0, MENU_SORT, 0, "Sort").setIcon(
+				R.drawable.menu_sort);
 		sortMenu.add(2, MENU_SORT_BY_TITLE_ASC, 0, "by Title ascending");
 		sortMenu.add(2, MENU_SORT_BY_TITLE_DESC, 0, "by Title descending");
 		sortMenu.add(2, MENU_SORT_BY_YEAR_ASC, 0, "by Year ascending");
 		sortMenu.add(2, MENU_SORT_BY_YEAR_DESC, 0, "by Year descending");
 		sortMenu.add(2, MENU_SORT_BY_RATING_ASC, 0, "by Rating ascending");
 		sortMenu.add(2, MENU_SORT_BY_RATING_DESC, 0, "by Rating descending");
-//		menu.add(0, MENU_SWITCH_VIEW, 0, "Switch view").setIcon(R.drawable.menu_view);
+		// menu.add(0, MENU_SWITCH_VIEW, 0,
+		// "Switch view").setIcon(R.drawable.menu_view);
 		createShowHideWatchedToggle(menu);
 	}
-	
+
 	@Override
 	public void onOptionsItemSelected(MenuItem item) {
-//		final SharedPreferences.Editor ed;
+		// final SharedPreferences.Editor ed;
 		switch (item.getItemId()) {
 		case MENU_PLAY_ALL:
 			break;
@@ -219,45 +247,53 @@ public class SeasonListController extends ListController implements IController 
 			super.onOptionsItemSelected(item);
 		}
 	}
-	
+
 	@Override
 	protected void refreshList() {
 		hideMessage();
 		fetch();
 	}
-	
+
 	private class SeasonAdapter extends ArrayAdapter<Season> {
 		SeasonAdapter(Activity activity, ArrayList<Season> items) {
 			super(activity, 0, items);
 		}
+
 		@Override
 		public View getView(int position, View convertView, ViewGroup parent) {
 
 			final GridPosterItemView view;
 			if (convertView == null) {
-				view = new GridPosterItemView(mActivity, mTvManager, parent.getWidth(), mFallbackBitmap, mList.getSelector(), false);
+				view = new GridPosterItemView(mActivity, mTvManager,
+						parent.getWidth(), mFallbackBitmap,
+						mList.getSelector(), false);
 			} else {
-				view = (GridPosterItemView)convertView;
+				view = (GridPosterItemView) convertView;
 			}
-			
+
 			final Season season = getItem(position);
 			view.reset();
 			view.position = position;
-			view.title = "Season " + season.number;
-			
+			if (season.number > 0) {
+				view.title = "Season " + season.number;
+			} else {
+				view.title = "Specials";
+			}
+
 			if (mLoadCovers) {
-				view.getResponse().load(season, ThumbSize.MEDIUM, !mPostScrollLoader.isListIdle());
+				view.getResponse().load(season, ThumbSize.MEDIUM,
+						!mPostScrollLoader.isListIdle());
 			}
 			return view;
 		}
 	}
-	
+
 	private static final long serialVersionUID = 1088971882661811256L;
 
 	public void onActivityPause() {
 		if (mTvManager != null) {
 			mTvManager.setController(null);
-//			mVideoManager.postActivity();
+			// mVideoManager.postActivity();
 		}
 		if (mControlManager != null) {
 			mControlManager.setController(null);

--- a/src/org/xbmc/android/remote/presentation/controller/SeasonListController.java
+++ b/src/org/xbmc/android/remote/presentation/controller/SeasonListController.java
@@ -124,7 +124,6 @@ public class SeasonListController extends ListController implements IController 
 				if (value.size() > 0) {
 					setTitle(title +" (" + value.size() + ")");
 					mList.setAdapter(new SeasonAdapter(mActivity, value));
-					preloadCovers(value, mTvManager, mThumbSize);
 				} else {
 					setTitle(title);
 					setNoDataMessage("No seasons found.", R.drawable.icon_movie_dark);

--- a/src/org/xbmc/android/remote/presentation/controller/SeasonListController.java
+++ b/src/org/xbmc/android/remote/presentation/controller/SeasonListController.java
@@ -274,11 +274,7 @@ public class SeasonListController extends ListController implements IController 
 			final Season season = getItem(position);
 			view.reset();
 			view.position = position;
-			if (season.number > 0) {
-				view.title = "Season " + season.number;
-			} else {
-				view.title = "Specials";
-			}
+			view.title = season.getShortName();
 
 			if (mLoadCovers) {
 				view.getResponse().load(season, ThumbSize.MEDIUM,

--- a/src/org/xbmc/android/remote/presentation/controller/SongListController.java
+++ b/src/org/xbmc/android/remote/presentation/controller/SongListController.java
@@ -168,7 +168,6 @@ public class SongListController extends ListController implements IController {
 				if (value.size() > 0) {
 					setTitle(title + " (" + value.size() + ")");
 					mList.setAdapter(new SongAdapter(mActivity, value));
-					preloadCovers(value, mMusicManager, mThumbSize);
 				} else {
 					setTitle(title);
 					setNoDataMessage("No songs found", R.drawable.icon_song_dark);

--- a/src/org/xbmc/android/remote/presentation/controller/SongListController.java
+++ b/src/org/xbmc/android/remote/presentation/controller/SongListController.java
@@ -168,7 +168,7 @@ public class SongListController extends ListController implements IController {
 				if (value.size() > 0) {
 					setTitle(title + " (" + value.size() + ")");
 					mList.setAdapter(new SongAdapter(mActivity, value));
-					cacheCovers(value, mMusicManager, mThumbSize);
+					preloadCovers(value, mMusicManager, mThumbSize);
 				} else {
 					setTitle(title);
 					setNoDataMessage("No songs found", R.drawable.icon_song_dark);
@@ -362,6 +362,7 @@ public class SongListController extends ListController implements IController {
 				if(mMusicManager.coverLoaded(song, mThumbSize)){
 					view.setCover(mMusicManager.getCoverSync(song, mThumbSize));
 				}else{
+					view.setCover(null);
 					view.getResponse().load(song, !mPostScrollLoader.isListIdle());
 				}
 			}

--- a/src/org/xbmc/android/remote/presentation/controller/SongListController.java
+++ b/src/org/xbmc/android/remote/presentation/controller/SongListController.java
@@ -36,6 +36,7 @@ import org.xbmc.api.object.Artist;
 import org.xbmc.api.object.Genre;
 import org.xbmc.api.object.Song;
 import org.xbmc.api.type.SortType;
+import org.xbmc.api.type.ThumbSize;
 
 import android.app.Activity;
 import android.content.Context;
@@ -59,6 +60,7 @@ import android.widget.AdapterView.OnItemClickListener;
 
 public class SongListController extends ListController implements IController {
 	
+	private static final int mThumbSize = ThumbSize.SMALL;
 	public static final int ITEM_CONTEXT_QUEUE = 1;
 	public static final int ITEM_CONTEXT_PLAY = 2;
 	public static final int ITEM_CONTEXT_INFO = 3;
@@ -160,50 +162,28 @@ public class SongListController extends ListController implements IController {
 	}
 	
 	private void fetch() {
-		final Album album = mAlbum; 
-		final Genre genre = mGenre; 
-		final Artist artist = mArtist; 
+		final String title = mAlbum != null ? mAlbum.name + " - " : mArtist != null ? mArtist.name + " - " : mGenre != null ? mGenre.name + " - " : "" + "Songs";
+		DataResponse<ArrayList<Song>> response = new DataResponse<ArrayList<Song>>() {
+			public void run() {
+				if (value.size() > 0) {
+					setTitle(title + " (" + value.size() + ")");
+					mList.setAdapter(new SongAdapter(mActivity, value));
+					cacheCovers(value, mMusicManager, mThumbSize);
+				} else {
+					setTitle(title);
+					setNoDataMessage("No songs found", R.drawable.icon_song_dark);
+				}
+			}
+		};
+		
 		showOnLoading();
-		if (album != null) {
-			setTitle("Songs...");
-			mMusicManager.getSongs(new DataResponse<ArrayList<Song>>() {
-				public void run() {
-					setTitle(album.name);
-					if (value.size() > 0) {
-						mList.setAdapter(new SongAdapter(mActivity, value));
-					} else {
-						setNoDataMessage("No songs found", R.drawable.icon_song_dark);
-					}
-				}
-			}, album, mActivity.getApplicationContext());
-			
-		} else if (artist != null) {
-			setTitle(artist.name + " - Songs...");
-			mMusicManager.getSongs(new DataResponse<ArrayList<Song>>() {
-				public void run() {
-					if (value.size() > 0) {
-						setTitle(artist.name + " - Songs (" + value.size() + ")");
-						mList.setAdapter(new SongAdapter(mActivity, value));
-					} else {
-						setTitle(artist.name + " - Songs");
-						setNoDataMessage("No songs found.", R.drawable.icon_song_dark);
-					}
-				}
-			}, artist, mActivity.getApplicationContext());
-			
-		} else if (genre != null) {
-			setTitle(genre.name + " - Songs...");
-			mMusicManager.getSongs(new DataResponse<ArrayList<Song>>() {
-				public void run() {
-					if (value.size() > 0) {
-						setTitle(genre.name + " - Songs (" + value.size() + ")");
-						mList.setAdapter(new SongAdapter(mActivity, value));
-					} else {
-						setTitle(genre.name + " - Songs");
-						setNoDataMessage("No songs found.", R.drawable.icon_song_dark);
-					}
-				}
-			}, genre, mActivity.getApplicationContext());
+		setTitle(title + "...");
+		if (mAlbum != null) {
+			mMusicManager.getSongs(response, mAlbum, mActivity.getApplicationContext());
+		} else if (mArtist != null) {
+			mMusicManager.getSongs(response, mArtist, mActivity.getApplicationContext());
+		} else if (mGenre != null) {
+			mMusicManager.getSongs(response, mGenre, mActivity.getApplicationContext());
 		}
 	}
 	
@@ -379,7 +359,11 @@ public class SongListController extends ListController implements IController {
 			view.subsubtitle = song.getDuration();
 			
 			if (mLoadCovers) {
-				view.getResponse().load(song, !mPostScrollLoader.isListIdle());
+				if(mMusicManager.coverLoaded(song, mThumbSize)){
+					view.setCover(mMusicManager.getCoverSync(song, mThumbSize));
+				}else{
+					view.getResponse().load(song, !mPostScrollLoader.isListIdle());
+				}
 			}
 			return view;
 		}

--- a/src/org/xbmc/android/remote/presentation/controller/TvShowListController.java
+++ b/src/org/xbmc/android/remote/presentation/controller/TvShowListController.java
@@ -139,7 +139,7 @@ public class TvShowListController extends ListController implements IController 
 				if (value.size() > 0) {
 					setTitle(title + " (" + value.size() + ")");
 					mList.setAdapter(new TvShowAdapter(mActivity, value));
-					cacheCovers(value, mTvManager, mThumbSize);
+					preloadCovers(value, mTvManager, mThumbSize);
 				} else {
 					setTitle(title);
 					setNoDataMessage("No TV shows found.", R.drawable.icon_movie_dark);
@@ -321,6 +321,7 @@ public class TvShowListController extends ListController implements IController 
 				if (mTvManager.coverLoaded(show, mThumbSize)) {
 					view.setCover(mTvManager.getCoverSync(show, mThumbSize));
 				} else {
+					view.setCover(null);
 					view.getResponse().load(show, !mPostScrollLoader.isListIdle());
 				}
 			}

--- a/src/org/xbmc/android/remote/presentation/controller/TvShowListController.java
+++ b/src/org/xbmc/android/remote/presentation/controller/TvShowListController.java
@@ -139,7 +139,6 @@ public class TvShowListController extends ListController implements IController 
 				if (value.size() > 0) {
 					setTitle(title + " (" + value.size() + ")");
 					mList.setAdapter(new TvShowAdapter(mActivity, value));
-					preloadCovers(value, mTvManager, mThumbSize);
 				} else {
 					setTitle(title);
 					setNoDataMessage("No TV shows found.", R.drawable.icon_movie_dark);

--- a/src/org/xbmc/android/remote/presentation/controller/TvShowListController.java
+++ b/src/org/xbmc/android/remote/presentation/controller/TvShowListController.java
@@ -39,6 +39,7 @@ import org.xbmc.api.object.Actor;
 import org.xbmc.api.object.Genre;
 import org.xbmc.api.object.TvShow;
 import org.xbmc.api.type.SortType;
+import org.xbmc.api.type.ThumbSize;
 
 import android.app.Activity;
 import android.app.AlertDialog;
@@ -65,6 +66,7 @@ import android.widget.AdapterView.OnItemClickListener;
 
 public class TvShowListController extends ListController implements IController {
 	
+	private static final int mThumbSize = ThumbSize.SMALL;
 	public static final int ITEM_CONTEXT_BROWSE = 1;
 	public static final int ITEM_CONTEXT_INFO = 2;
 	
@@ -127,54 +129,32 @@ public class TvShowListController extends ListController implements IController 
 	}
 	
 	private void fetch() {
-		final Actor actor = mActor;
-		final Genre genre = mGenre;
-		
 		// tv show and episode both are using the same manager so set the sort key here
 		((ISortableManager)mTvManager).setSortKey(AbstractManager.PREF_SORT_KEY_SHOW);
 		((ISortableManager)mTvManager).setPreferences(mActivity.getPreferences(Context.MODE_PRIVATE));
+
+		final String title = mActor != null ? mActor.name + " - " : mGenre != null ? mGenre.name + " - " : "" + "TV Shows";
+		DataResponse<ArrayList<TvShow>> response = new DataResponse<ArrayList<TvShow>>() {
+			public void run() {
+				if (value.size() > 0) {
+					setTitle(title + " (" + value.size() + ")");
+					mList.setAdapter(new TvShowAdapter(mActivity, value));
+					cacheCovers(value, mTvManager, mThumbSize);
+				} else {
+					setTitle(title);
+					setNoDataMessage("No TV shows found.", R.drawable.icon_movie_dark);
+				}
+			}
+		};
 		
 		showOnLoading();
-		if (actor != null) {						// TV Shows with a certain actor
-			setTitle(actor.name + " - TV Shows...");
-			mTvManager.getTvShows(new DataResponse<ArrayList<TvShow>>() {
-				public void run() {
-					if (value.size() > 0) {
-						setTitle(actor.name + " - TV Shows (" + value.size() + ")");
-						mList.setAdapter(new TvShowAdapter(mActivity, value));
-					} else {
-						setTitle(actor.name + " - TV Shows");
-						setNoDataMessage("No TV shows found.", R.drawable.icon_movie_dark);
-					}
-				}
-			}, actor, mActivity.getApplicationContext());
-			
-		} else if (genre != null) {					// TV Shows of a genre
-			setTitle(genre.name + " - TV Shows...");
-			mTvManager.getTvShows(new DataResponse<ArrayList<TvShow>>() {
-				public void run() {
-					if (value.size() > 0) {
-						setTitle(genre.name + " - TV Shows (" + value.size() + ")");
-						mList.setAdapter(new TvShowAdapter(mActivity, value));
-					} else {
-						setTitle(genre.name + " - TV Shows");
-						setNoDataMessage("No tv shows found.", R.drawable.icon_movie_dark);
-					}
-				}
-			}, genre, mActivity.getApplicationContext());
-		} else {
-			setTitle("TV Shows...");				// all TV Shows
-			mTvManager.getTvShows(new DataResponse<ArrayList<TvShow>>() {
-				public void run() {
-					if (value.size() > 0) {
-						setTitle("TV Shows (" + value.size() + ")");
-						mList.setAdapter(new TvShowAdapter(mActivity, value));
-					} else {
-						setTitle("TV Shows");
-						setNoDataMessage("No TV Shows found.", R.drawable.icon_movie_dark);
-					}
-				}
-			}, mActivity.getApplicationContext());
+		setTitle(title + "...");		
+		if (mActor != null) {						// TV Shows with a certain actor
+			mTvManager.getTvShows(response, mActor, mActivity.getApplicationContext());
+		} else if (mGenre != null) {					// TV Shows of a genre
+			mTvManager.getTvShows(response, mGenre, mActivity.getApplicationContext());
+		} else {									// all TV Shows
+			mTvManager.getTvShows(response, mActivity.getApplicationContext());
 		}
 	}
 	
@@ -316,27 +296,33 @@ public class TvShowListController extends ListController implements IController 
 		TvShowAdapter(Activity activity, ArrayList<TvShow> items) {
 			super(activity, 0, items);
 		}
+
 		public View getView(int position, View convertView, ViewGroup parent) {
 
 			final FlexibleItemView view;
 			if (convertView == null) {
-				view = new FlexibleItemView(mActivity, mTvManager, parent.getWidth(), mFallbackBitmap, mList.getSelector(), false);
+				view = new FlexibleItemView(mActivity, mTvManager, parent.getWidth(), mFallbackBitmap,
+						mList.getSelector(), false);
 			} else {
-				view = (FlexibleItemView)convertView;
+				view = (FlexibleItemView) convertView;
 			}
-			
+
 			final TvShow show = getItem(position);
 			view.reset();
 			view.position = position;
 			view.posterOverlay = show.watched ? mWatchedBitmap : null;
 			view.title = show.title;
 			view.subtitle = show.genre;
-			view.subtitleRight = show.firstAired!=null?show.firstAired:"";
+			view.subtitleRight = show.firstAired != null ? show.firstAired : "";
 			view.bottomtitle = show.numEpisodes + " episodes";
-			view.bottomright = String.valueOf(((float)Math.round(show.rating *10))/ 10);
-			
+			view.bottomright = String.valueOf(((float) Math.round(show.rating * 10)) / 10);
+
 			if (mLoadCovers) {
-				view.getResponse().load(show, !mPostScrollLoader.isListIdle());
+				if (mTvManager.coverLoaded(show, mThumbSize)) {
+					view.setCover(mTvManager.getCoverSync(show, mThumbSize));
+				} else {
+					view.getResponse().load(show, !mPostScrollLoader.isListIdle());
+				}
 			}
 			return view;
 		}

--- a/src/org/xbmc/android/remote/presentation/widget/AbstractItemView.java
+++ b/src/org/xbmc/android/remote/presentation/widget/AbstractItemView.java
@@ -78,12 +78,10 @@ public abstract class AbstractItemView extends View {
 		this(context, null, width, defaultCover, selection, 0, fixedSize);
 	}
 	
-	
 	protected void drawPoster(Canvas canvas, int posterWidth, int posterHeight, int canvasWidth) {
 
 		// background
-		if ((isSelected() || isPressed()) && mSelection != null) { // && sSelected != null && !sSelected.isRecycled()) {
-//			canvas.drawBitmap(sSelected, null, new Rect(posterWidth, 0, canvasWidth, posterHeight), PAINT);
+		if ((isSelected() || isPressed()) && mSelection != null) {
 			mSelection.setBounds(posterWidth, 0, canvasWidth, posterHeight);
 			mSelection.draw(canvas);
 		} else {
@@ -92,30 +90,21 @@ public abstract class AbstractItemView extends View {
 		}
 		
 		// poster
-		if (mCover != null && !mCover.isRecycled()) {
-			final int w = mCover.getWidth();
-			final int h = mCover.getHeight();
-			int dx = 0;
-			int dy = 0;
-			if (w > posterWidth) {
-				dx = (w - posterWidth) / 2;  
-			}
-			if (h > posterHeight) {
-				dy = (h - posterHeight) / 2;  
-			}
-			if (dx > 0 || dy > 0) {
-				canvas.drawBitmap(mCover, new Rect(dx, dy, dx + posterWidth, dy + posterHeight), getPosterRect(), PAINT);
-			} else {
-				canvas.drawBitmap(mCover, 0.0f, 0.0f, null);
-			}
-		} else {
-			final Bitmap defaultCover = mDefaultCover;
-			if (defaultCover != null && !defaultCover.isRecycled()) {
-				PAINT.setColor(Color.WHITE);
-				canvas.drawRect(0, 0, posterWidth, posterHeight, PAINT);
-//				canvas.drawBitmap(defaultCover, 0f, 0f, PAINT);
-				canvas.drawBitmap(defaultCover, new Rect(0, 0, defaultCover.getWidth(), defaultCover.getHeight()), new Rect(0, 0, posterWidth, posterHeight), PAINT);
-			}
+		Bitmap cover = mCover;
+		if(mCover == null || mCover.isRecycled())
+		{
+			cover = mDefaultCover;
+		}
+		
+		if (cover != null && !cover.isRecycled()) {
+			int dx = (cover.getWidth() - posterWidth) / 2;  
+			int dy = (cover.getHeight() - posterHeight) / 2;
+			Rect src = null;
+			if(dx > 0 || dy > 0) {
+					src = new Rect(dx, dy, dx + posterWidth, dy + posterHeight);
+				}
+			Rect dst = getPosterRect();
+			canvas.drawBitmap(cover, src, dst, PAINT);
 		}
 	}
 	

--- a/src/org/xbmc/android/remote/presentation/widget/AbstractItemView.java
+++ b/src/org/xbmc/android/remote/presentation/widget/AbstractItemView.java
@@ -30,6 +30,7 @@ public abstract class AbstractItemView extends View {
 	protected Bitmap mCover;
 	protected final int mWidth;
 	protected final Drawable mSelection;
+	protected int mDefaultColor = Color.WHITE;
 	
 	private final Handler mHandler = new Handler() {
 		public void handleMessage(android.os.Message msg) {
@@ -79,13 +80,12 @@ public abstract class AbstractItemView extends View {
 	}
 	
 	protected void drawPoster(Canvas canvas, int posterWidth, int posterHeight, int canvasWidth) {
-
 		// background
 		if ((isSelected() || isPressed()) && mSelection != null) {
 			mSelection.setBounds(posterWidth, 0, canvasWidth, posterHeight);
 			mSelection.draw(canvas);
 		} else {
-			PAINT.setColor(Color.WHITE);
+			PAINT.setColor(mDefaultColor);
 			canvas.drawRect(posterWidth, 0, canvasWidth, posterHeight, PAINT);
 		}
 		
@@ -104,6 +104,8 @@ public abstract class AbstractItemView extends View {
 					src = new Rect(dx, dy, dx + posterWidth, dy + posterHeight);
 				}
 			Rect dst = getPosterRect();
+			PAINT.setColor(mDefaultColor);
+			canvas.drawRect(0, 0, posterWidth, posterHeight, PAINT);
 			canvas.drawBitmap(cover, src, dst, PAINT);
 		}
 	}

--- a/src/org/xbmc/android/remote/presentation/widget/FiveLabelsItemView.java
+++ b/src/org/xbmc/android/remote/presentation/widget/FiveLabelsItemView.java
@@ -13,8 +13,9 @@ import android.graphics.drawable.Drawable;
 
 public class FiveLabelsItemView extends AbstractItemView {
 	
-	private final int posterWidth, posterHeight;
-	private final Rect posterRect;
+	protected int posterWidth;
+	protected int posterHeight;
+	protected Rect posterRect;
 	
 	public Bitmap posterOverlay;
 	public String subtitle;

--- a/src/org/xbmc/android/remote/presentation/widget/FlexibleItemView.java
+++ b/src/org/xbmc/android/remote/presentation/widget/FlexibleItemView.java
@@ -17,9 +17,10 @@ public class FlexibleItemView extends FiveLabelsItemView {
 	
 //	private static final String TAG = "FlexibleItemView";
 	
-	private final static int POSTER_WIDTH = ThumbSize.getPixel(ThumbSize.SMALL);;
-	private final static int POSTER_HEIGHT = (int)(POSTER_WIDTH * ThumbSize.POSTER_AR);
-	private final static Rect POSTER_RECT = new Rect(0, 0, POSTER_WIDTH, POSTER_HEIGHT);
+	private int POSTER_WIDTH = ThumbSize.getPixel(ThumbSize.SMALL);
+	private int POSTER_HEIGHT = (int)(POSTER_WIDTH * ThumbSize.POSTER_AR);
+	private Rect POSTER_RECT = new Rect(0, 0, POSTER_WIDTH, POSTER_HEIGHT);
+	private int POSTER_FORMAT = Dimension.PORTRAIT;
 	
 	public FlexibleItemView(Context context, IManager manager, int width, Bitmap defaultCover, Drawable selection, boolean fixedSize) {
 		super(context, manager, width, defaultCover, selection, fixedSize);
@@ -27,25 +28,20 @@ public class FlexibleItemView extends FiveLabelsItemView {
 
 	@Override
 	protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
-		if (mCover == null) {
-			setMeasuredDimension(mWidth, POSTER_HEIGHT);
-		} else {
-			setMeasuredDimension(mWidth, mCover.getHeight());
-		}
+		setMeasuredDimension(mWidth, POSTER_HEIGHT);
 	}
-
+	
 	protected void onDraw(Canvas canvas) {
 		if (mCover != null && !mCover.isRecycled()) {
-			Dimension renderDim = ThumbSize.getDimension(ThumbSize.SMALL, MediaType.VIDEO, mCover.getWidth(), mCover.getHeight());
-			drawPoster(canvas, renderDim.x, renderDim.y, mWidth);
-			drawPosterOverlay(canvas, renderDim.x, renderDim.y);
-			switch (renderDim.format) {
+			drawPoster(canvas, POSTER_WIDTH, POSTER_HEIGHT, mWidth);
+			drawPosterOverlay(canvas, POSTER_WIDTH, POSTER_HEIGHT);
+			switch (POSTER_FORMAT) {
 				case Dimension.SQUARE:
 				case Dimension.PORTRAIT:
 					drawPortrait(canvas);
 					break;
 				case Dimension.LANDSCAPE:
-					drawLandscape(canvas, renderDim);
+					drawLandscape(canvas, POSTER_WIDTH);
 					break;
 				case Dimension.BANNER:
 					drawBanner(canvas);
@@ -71,7 +67,7 @@ public class FlexibleItemView extends FiveLabelsItemView {
 	 * </pre>
 	 * @param canvas Canvas to draw on
 	 */
-	private void drawLandscape(Canvas canvas, Dimension coverDim) {
+	private void drawLandscape(Canvas canvas, int drawWidth) {
 		final int width = mWidth;
 		final boolean isSelected = isSelected() || isPressed();
 		
@@ -86,7 +82,7 @@ public class FlexibleItemView extends FiveLabelsItemView {
 		if (title != null) {
 			PAINT.setColor(isSelected ? Color.WHITE : Color.BLACK);
 			PAINT.setTextSize(size18);
-			canvas.drawText(ellipse(title, width - coverDim.x + padding), coverDim.x + padding, size25, PAINT);
+			canvas.drawText(ellipse(title, width - drawWidth + padding), drawWidth + padding, size25, PAINT);
 		}
 		
 		// subtitle right
@@ -105,7 +101,7 @@ public class FlexibleItemView extends FiveLabelsItemView {
 		PAINT.setTextAlign(Align.LEFT);
 		PAINT.setFakeBoldText(false);
 		if (subtitle != null) {
-			canvas.drawText(ellipse(subtitle, width - (int)subtitleRightWidth - size50), coverDim.x + padding, size42, PAINT);
+			canvas.drawText(ellipse(subtitle, width - (int)subtitleRightWidth - size50), drawWidth + padding, size42, PAINT);
 		}
 		
 	}
@@ -117,6 +113,21 @@ public class FlexibleItemView extends FiveLabelsItemView {
 	
 	public void setCover(Bitmap cover) {
 		mCover = cover;
+		if(mCover != null)
+		{
+			Dimension renderDim = ThumbSize.getDimension(ThumbSize.SMALL, MediaType.VIDEO, mCover.getWidth(), mCover.getHeight());
+			POSTER_WIDTH = renderDim.x;
+			POSTER_HEIGHT = renderDim.y;
+			POSTER_RECT = new Rect(0, 0, POSTER_WIDTH, POSTER_HEIGHT);
+			POSTER_FORMAT = renderDim.format;
+		}
+		else
+		{
+			POSTER_WIDTH = ThumbSize.getPixel(ThumbSize.SMALL);
+			POSTER_HEIGHT = (int)(POSTER_WIDTH * ThumbSize.POSTER_AR);
+			POSTER_RECT = new Rect(0, 0, POSTER_WIDTH, POSTER_HEIGHT);
+			POSTER_FORMAT = Dimension.PORTRAIT;
+		}
 		requestLayout();
 		invalidate();
 	}

--- a/src/org/xbmc/android/remote/presentation/widget/FlexibleItemView.java
+++ b/src/org/xbmc/android/remote/presentation/widget/FlexibleItemView.java
@@ -14,34 +14,23 @@ import android.graphics.Paint.Align;
 import android.graphics.drawable.Drawable;
 
 public class FlexibleItemView extends FiveLabelsItemView {
-	
-//	private static final String TAG = "FlexibleItemView";
-	
-	private int POSTER_WIDTH = ThumbSize.getPixel(ThumbSize.SMALL);
-	private int POSTER_HEIGHT = (int)(POSTER_WIDTH * ThumbSize.POSTER_AR);
-	private Rect POSTER_RECT = new Rect(0, 0, POSTER_WIDTH, POSTER_HEIGHT);
-	private int POSTER_FORMAT = Dimension.PORTRAIT;
+		private int POSTER_FORMAT = Dimension.PORTRAIT;
 	
 	public FlexibleItemView(Context context, IManager manager, int width, Bitmap defaultCover, Drawable selection, boolean fixedSize) {
 		super(context, manager, width, defaultCover, selection, fixedSize);
 	}
-
-	@Override
-	protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
-		setMeasuredDimension(mWidth, POSTER_HEIGHT);
-	}
 	
 	protected void onDraw(Canvas canvas) {
 		if (mCover != null && !mCover.isRecycled()) {
-			drawPoster(canvas, POSTER_WIDTH, POSTER_HEIGHT, mWidth);
-			drawPosterOverlay(canvas, POSTER_WIDTH, POSTER_HEIGHT);
+			drawPoster(canvas, posterWidth, posterHeight, mWidth);
+			drawPosterOverlay(canvas, posterWidth, posterHeight);
 			switch (POSTER_FORMAT) {
 				case Dimension.SQUARE:
 				case Dimension.PORTRAIT:
 					drawPortrait(canvas);
 					break;
 				case Dimension.LANDSCAPE:
-					drawLandscape(canvas, POSTER_WIDTH);
+					drawLandscape(canvas, posterWidth);
 					break;
 				case Dimension.BANNER:
 					drawBanner(canvas);
@@ -115,25 +104,20 @@ public class FlexibleItemView extends FiveLabelsItemView {
 		mCover = cover;
 		if(mCover != null)
 		{
-			Dimension renderDim = ThumbSize.getDimension(ThumbSize.SMALL, MediaType.VIDEO, mCover.getWidth(), mCover.getHeight());
-			POSTER_WIDTH = renderDim.x;
-			POSTER_HEIGHT = renderDim.y;
-			POSTER_RECT = new Rect(0, 0, POSTER_WIDTH, POSTER_HEIGHT);
+			Dimension renderDim = ThumbSize.getTargetDimension(ThumbSize.SMALL, MediaType.VIDEO, mCover.getWidth(), mCover.getHeight());
+			posterWidth = renderDim.x;
+			posterHeight = renderDim.y;
+			posterRect = new Rect(0, 0, posterWidth, posterHeight);
 			POSTER_FORMAT = renderDim.format;
 		}
 		else
 		{
-			POSTER_WIDTH = ThumbSize.getPixel(ThumbSize.SMALL);
-			POSTER_HEIGHT = (int)(POSTER_WIDTH * ThumbSize.POSTER_AR);
-			POSTER_RECT = new Rect(0, 0, POSTER_WIDTH, POSTER_HEIGHT);
+			posterWidth = ThumbSize.getPixel(ThumbSize.SMALL);
+			posterHeight = (int)(posterWidth * ThumbSize.POSTER_AR);
+			posterRect = new Rect(0, 0, posterWidth, posterHeight);
 			POSTER_FORMAT = Dimension.PORTRAIT;
 		}
 		requestLayout();
 		invalidate();
-	}
-	
-	@Override
-	protected Rect getPosterRect() {
-		return POSTER_RECT;
 	}
 }

--- a/src/org/xbmc/android/widget/slidingtabs/SlidingTabActivity.java
+++ b/src/org/xbmc/android/widget/slidingtabs/SlidingTabActivity.java
@@ -26,12 +26,14 @@ import org.xbmc.android.remote.presentation.activity.HomeActivity;
 import org.xbmc.android.util.KeyTracker;
 import org.xbmc.android.util.OnLongPressBackKeyTracker;
 import org.xbmc.android.util.KeyTracker.Stage;
+import org.xbmc.api.type.ThumbSize;
 
 import android.app.Activity;
 import android.app.ActivityGroup;
 import android.content.Intent;
 import android.os.Bundle;
 import android.os.Build.VERSION;
+import android.view.Display;
 import android.view.KeyEvent;
 import android.view.View;
 import android.widget.TabHost;
@@ -63,6 +65,13 @@ public class SlidingTabActivity extends ActivityGroup {
 				
 			});
 		}
+	}
+
+	protected void onCreate(Bundle savedInstanceState) {
+		super.onCreate(savedInstanceState);
+		// set display size
+		final Display display = getWindowManager().getDefaultDisplay(); 
+		ThumbSize.setScreenSize(display.getWidth(), display.getHeight());		
 	}
 	
 	protected void callSuperOnKeyDown(int keyCode, KeyEvent event) {

--- a/src/org/xbmc/api/business/CoverResponse.java
+++ b/src/org/xbmc/api/business/CoverResponse.java
@@ -42,7 +42,9 @@ public class CoverResponse extends DataResponse<Bitmap> {
 	
 	public synchronized void run() {
 		if (mMostRecentCover == null) {
-			mHandler.sendMessage(mHandler.obtainMessage(AbstractItemView.MSG_UPDATE_COVER, value));
+			if(mHandler != null) {
+				mHandler.sendMessage(mHandler.obtainMessage(AbstractItemView.MSG_UPDATE_COVER, value));
+			}
 			mIsLoading = false;
 		} else {
 			mManager.getCover(this, mMostRecentCover, mThumbSize, mDefaultCover, mContext, false);

--- a/src/org/xbmc/api/business/IManager.java
+++ b/src/org/xbmc/api/business/IManager.java
@@ -41,4 +41,7 @@ public interface IManager {
 	 * @param response Response object
 	 */
 	public void getCover(final DataResponse<Bitmap> response, final ICoverArt cover, final int thumbSize, Bitmap defaultCover, final Context context, final boolean getFromCacheOnly);
+	public Bitmap getCoverSync(final ICoverArt cover, final int thumbSize);
+	public boolean coverLoaded(final ICoverArt cover, final int thumbSize);
+	public void post(Runnable runnable);
 }

--- a/src/org/xbmc/api/object/Episode.java
+++ b/src/org/xbmc/api/object/Episode.java
@@ -130,7 +130,10 @@ public class Episode implements ICoverArt {
 	}
 
 	public String getName() {
-		return season + "x" + episode + ": " + title;
+		if(season == 0)
+			return "Special " + episode + ": " + title;
+		else
+			return season + "x" + episode + ": " + title;
 	}
 
 	/**

--- a/src/org/xbmc/api/object/Season.java
+++ b/src/org/xbmc/api/object/Season.java
@@ -46,13 +46,7 @@ public class Season implements Serializable, ICoverArt {
 	public long getCrc() {
 		// FileItem.cpp(1185)
 		// BGetCachedThumb("season"+seasonPath+GetLabel(),g_settings.GetVideoThumbFolder(),true);
-		if (number > 0) {
-			return Crc32.computeLowerCase("season" + show.getPath() + "Season "
-					+ number);
-		} else {
-			return Crc32.computeLowerCase("season" + show.getPath()
-					+ "Specials");
-		}
+			return Crc32.computeLowerCase("season" + show.getPath() + getShortName());
 	}
 
 	public int getFallbackCrc() {
@@ -68,12 +62,16 @@ public class Season implements Serializable, ICoverArt {
 		return MediaType.VIDEO_TVSEASON;
 	}
 
-	public String getName() {
+	public String getShortName() {
 		if (number > 0) {
-			return show.getName() + " - Season " + number;
+			return "Season " + number;
 		} else {
-			return show.getName() + " - Specials";
+			return "Specials";
 		}
+	}
+
+	public String getName() {
+		return show.getName() + " " + getShortName();
 	}
 
 	public String getPath() {

--- a/src/org/xbmc/api/object/Season.java
+++ b/src/org/xbmc/api/object/Season.java
@@ -32,38 +32,55 @@ public class Season implements Serializable, ICoverArt {
 	public final int number;
 	public final boolean watched;
 	public final TvShow show;
-	
+
 	public List<Episode> episodes = null;
-	
+
 	public Season(int number, boolean watched, TvShow show) {
 		this.number = number;
 		this.watched = watched;
 		this.show = show;
 	}
+
 	private static final long serialVersionUID = -7652780720536304140L;
 
 	public long getCrc() {
 		// FileItem.cpp(1185)
 		// BGetCachedThumb("season"+seasonPath+GetLabel(),g_settings.GetVideoThumbFolder(),true);
-		return Crc32.computeLowerCase("season" + show.getPath() + "Season " + number);
+		if (number > 0) {
+			return Crc32.computeLowerCase("season" + show.getPath() + "Season "
+					+ number);
+		} else {
+			return Crc32.computeLowerCase("season" + show.getPath()
+					+ "Specials");
+		}
 	}
+
 	public int getFallbackCrc() {
 		return 0;
 	}
+
 	public int getId() {
 		// TODO Auto-generated method stub
 		return show.getId() * 10000 + number;
 	}
+
 	public int getMediaType() {
 		return MediaType.VIDEO_TVSEASON;
 	}
+
 	public String getName() {
-		return show.getName() + " - Season " + number;
+		if (number > 0) {
+			return show.getName() + " - Season " + number;
+		} else {
+			return show.getName() + " - Specials";
+		}
 	}
+
 	public String getPath() {
 		// TODO Auto-generated method stub
 		return null;
 	}
+
 	public String toString() {
 		return getName();
 	}

--- a/src/org/xbmc/api/type/ThumbSize.java
+++ b/src/org/xbmc/api/type/ThumbSize.java
@@ -38,6 +38,7 @@ public abstract class ThumbSize {
 	public static final double POSTER_AR = 1.4799154334038054968287526427061;
 	public static final double LANDSCAPE_AR = 0.5625;
 	public static final double BANNER_AR = 0.1846965699208443;
+	public static final double FULL_AR = 0.75;
 	
 	public static final int SMALL = 1;
 	public static final int MEDIUM = 2;
@@ -125,6 +126,8 @@ public abstract class ThumbSize {
 				return new Dimension(getPixel(size), getPixel(size), Dimension.SQUARE);
 			} else if (ar < 1) {			// portrait
 				return new Dimension(getPixel(size), (int)(POSTER_AR * getPixel(size)), Dimension.PORTRAIT);
+			} else if (ar < 1.5) { // landscape 4:3
+				return new Dimension((int)((double)getPixel(size) / FULL_AR), getPixel(size), Dimension.LANDSCAPE);
 			} else if (ar < 2) {			// landscape 16:9
 				return new Dimension((int)((double)getPixel(size) / LANDSCAPE_AR), getPixel(size), Dimension.LANDSCAPE);
 			} else if (ar > 5) {			// wide banner
@@ -146,90 +149,6 @@ public abstract class ThumbSize {
 				return new Dimension((int)((double)getPixel(size) / LANDSCAPE_AR), getPixel(size), Dimension.UNKNOWN);
 			}
 		}
-	}
-	
-	/**
-	 * Returns the dimensions the bitmap should be resized to before being 
-	 * cropped. Returned dimensions are with the same aspect ratio as input
-	 * parameters.
-	 * @param size      Which size
-	 * @param mediaType Which media type
-	 * @param x         Current image width
-	 * @param y         Current image height
-	 * @return
-	 */
-	public static Dimension getDimension(int size, int mediaType, int x, int y) {
-		int width = 0;
-		int height = 0;
-		int format = Dimension.UNKNOWN;
-		final double ar = ((double)x) / ((double)y);
-		switch (mediaType) {
-			default:
-			case MediaType.PICTURES:
-			case MediaType.MUSIC:
-				if (ar < 1) {
-					width = getPixel(size);
-					height = (int)((double)width / ar);
-				} else {
-					height = getPixel(size);
-					width = (int)((double)height * ar);
-				}
-				format = Dimension.SQUARE;
-				break;
-			case MediaType.VIDEO:
-			case MediaType.VIDEO_MOVIE:
-			case MediaType.VIDEO_TVEPISODE:
-			case MediaType.VIDEO_TVSEASON:
-			case MediaType.VIDEO_TVSHOW:
-				if (ar > 0.98 && ar < 1.02) { 	// square
-					if (ar < 1) {
-						width = getPixel(size);
-						height = (int)((double)width / ar);
-					} else {
-						height = getPixel(size);
-						width = (int)((double)height * ar);
-					}
-					format = Dimension.SQUARE;
-				} else if (ar < 1) {			// portrait
-					width = ThumbSize.getPixel(size);
-					final int ph = (int)(POSTER_AR * width);
-					height = (int)(width / ar); 
-					if (height < ph) { 
-						height = ph;
-						width = (int)(height * ar);
-					}
-					format = Dimension.PORTRAIT;
-				} else if (ar < 2) {			// landscape 16:9
-					height = ThumbSize.getPixel(size);
-					width = (int)(height * ar); 
-					format = Dimension.LANDSCAPE;
-				} else if (ar > 5) {			// wide banner
-					switch (size) {
-						case ThumbSize.SMALL:
-							width = ThumbSize.getPixel(ThumbSize.SCREENWIDTH);
-							height = (int)(width / ar); 
-							break;
-						case ThumbSize.MEDIUM:
-							width = ThumbSize.getPixel(ThumbSize.SCREENHEIGHT);
-							height = (int)(width / ar); 
-							break;
-						case ThumbSize.BIG:
-							height = 188;
-							width = (int)(height * ar); 
-							break;
-						default: 
-							height = -1;
-							width = -1;
-							break;
-					}
-					format = Dimension.BANNER;
-				} else {						// anything between wide banner and landscape 16:9
-					height = ThumbSize.getPixel(size);
-					width = (int)(height * ar); 
-				}
-				break;
-		}
-		return new Dimension(width, height, format);
 	}
 	
 	public static int[] values() {

--- a/src/org/xbmc/httpapi/Connection.java
+++ b/src/org/xbmc/httpapi/Connection.java
@@ -28,6 +28,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLDecoder;
@@ -449,6 +450,28 @@ public class Connection {
 		}
 
 		return uc;
+	}
+	
+	public byte[] download(String pathToDownload) throws IOException, URISyntaxException {
+		try {
+			final URL url = new URL(pathToDownload);
+			final URLConnection uc = getUrlConnection(url);
+			
+			final InputStream is = uc.getInputStream();
+			final InputStreamReader isr = new InputStreamReader(is);
+			final BufferedReader rd = new BufferedReader(isr, 8192);
+			
+			final StringBuilder sb = new StringBuilder();
+			String line = "";
+			while ((line = rd.readLine()) != null) {    
+				sb.append(line);
+			}
+			
+			rd.close();
+			return Base64.decode(sb.toString().replace("<html>", "").replace("</html>", ""));
+		} catch (Exception e) {
+			return null;
+		}
 	}
 
 	/**

--- a/src/org/xbmc/httpapi/client/Client.java
+++ b/src/org/xbmc/httpapi/client/Client.java
@@ -119,7 +119,7 @@ abstract class Client {
 				
 				if (bytes.length > 0) {
 					final BitmapFactory.Options opts = prefetch(manager, bytes, size);
-					final Dimension dim = ThumbSize.getDimension(size, mediaType, opts.outWidth, opts.outHeight);
+					final Dimension dim = ThumbSize.getTargetDimension(size, mediaType, opts.outWidth, opts.outHeight);
 					final int ss = ImportUtilities.calculateSampleSize(opts, dim);
 					opts.inDither = true;
 					opts.inSampleSize = ss;
@@ -165,14 +165,14 @@ abstract class Client {
 			
 			Log.i(TAG, "Starting download (" + url + ") - microhttpd");
 			BitmapFactory.Options opts = prefetch(manager, url, size);
-			Dimension dim = ThumbSize.getDimension(size, mediaType, opts.outWidth, opts.outHeight);
+			Dimension dim = ThumbSize.getTargetDimension(size, mediaType, opts.outWidth, opts.outHeight);
 			
 			Log.i(TAG, "Pre-fetch: " + opts.outWidth + "x" + opts.outHeight + " => " + dim);
 			if (opts.outWidth < 1) {
 				if (fallbackUrl != null) {
 					Log.i(TAG, "Starting fallback download (" + fallbackUrl + ")");
 					opts = prefetch(manager, fallbackUrl, size);
-					dim = ThumbSize.getDimension(size, mediaType, opts.outWidth, opts.outHeight);
+					dim = ThumbSize.getTargetDimension(size, mediaType, opts.outWidth, opts.outHeight);
 					Log.i(TAG, "FALLBACK-Pre-fetch: " + opts.outWidth + "x" + opts.outHeight + " => " + dim);
 					if (opts.outWidth < 1) {
 						return null;

--- a/src/org/xbmc/httpapi/client/TvShowClient.java
+++ b/src/org/xbmc/httpapi/client/TvShowClient.java
@@ -465,7 +465,12 @@ public class TvShowClient extends Client implements ITvShowClient {
 				return parseTime(map.get("Duration"));
 			}
 			public String getArtist() {
-				return "Season " + map.get("Season") + " / Episode " + map.get("Episode");
+				if(Integer.valueOf(map.get("Season")) == 0) {
+					return "Specials / Episode " + map.get("Episode");
+				}
+				else {
+					return "Season " + map.get("Season") + " / Episode " + map.get("Episode");
+				}
 			}
 			public String getAlbum() {
 				return map.get("Title");

--- a/src/org/xbmc/jsonrpc/client/Client.java
+++ b/src/org/xbmc/jsonrpc/client/Client.java
@@ -92,14 +92,14 @@ public abstract class Client {
 			Log.i(TAG, "Starting download (" + url + ")");
 			
 			BitmapFactory.Options opts = prefetch(manager, url, size, mediaType);
-			Dimension dim = ThumbSize.getDimension(size, mediaType, opts.outWidth, opts.outHeight);
+			Dimension dim = ThumbSize.getTargetDimension(size, mediaType, opts.outWidth, opts.outHeight);
 			
 			Log.i(TAG, "Pre-fetch: " + opts.outWidth + "x" + opts.outHeight + " => " + dim);
 			if (opts.outWidth < 0) {
 				if (fallbackUrl != null) {
 					Log.i(TAG, "Starting fallback download (" + fallbackUrl + ")");
 					opts = prefetch(manager, fallbackUrl, size, mediaType);
-					dim = ThumbSize.getDimension(size, mediaType, opts.outWidth, opts.outHeight);
+					dim = ThumbSize.getTargetDimension(size, mediaType, opts.outWidth, opts.outHeight);
 					Log.i(TAG, "FALLBACK-Pre-fetch: " + opts.outWidth + "x" + opts.outHeight + " => " + dim);
 					if (opts.outWidth < 0) {
 						return null;


### PR DESCRIPTION
Season 0 now interpreted as "Specials" this is in line with XBMC and fixes cover art for the Specials season as well as the displayed text
moved the download code for the now playing screen into the connection class and use the methods there to get the connection.  this fixes a problem with 401 being returned from XBMC when requesting the thumbnail
Added pre-fetching of covers that are in cache (from disk to mem).  And load covers from memCache synchronously when an item id drawn.  This prevents the flashing from the 'default' to the final cover when scrolling a list.  
