### PR TITLE
Normal thumbs

### DIFF
--- a/src/org/xbmc/android/remote/presentation/widget/FiveLabelsItemView.java
+++ b/src/org/xbmc/android/remote/presentation/widget/FiveLabelsItemView.java
@@ -13,8 +13,9 @@ import android.graphics.drawable.Drawable;
 
 public class FiveLabelsItemView extends AbstractItemView {
 	
-	private final int posterWidth, posterHeight;
-	private final Rect posterRect;
+	protected int posterWidth;
+	protected int posterHeight;
+	protected Rect posterRect;
 	
 	public Bitmap posterOverlay;
 	public String subtitle;

--- a/src/org/xbmc/android/remote/presentation/widget/FlexibleItemView.java
+++ b/src/org/xbmc/android/remote/presentation/widget/FlexibleItemView.java
@@ -104,9 +104,4 @@ public class FlexibleItemView extends FiveLabelsItemView {
 		requestLayout();
 		invalidate();
 	}
-	
-	@Override
-	protected Rect getPosterRect() {
-		return POSTER_RECT;
-	}
 }

--- a/src/org/xbmc/android/remote/presentation/widget/FlexibleItemView.java
+++ b/src/org/xbmc/android/remote/presentation/widget/FlexibleItemView.java
@@ -9,34 +9,18 @@ import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
 import android.graphics.Color;
-import android.graphics.Rect;
 import android.graphics.Paint.Align;
 import android.graphics.drawable.Drawable;
 
 public class FlexibleItemView extends FiveLabelsItemView {
-	
-//	private static final String TAG = "FlexibleItemView";
-	
-	private final static int POSTER_WIDTH = ThumbSize.getPixel(ThumbSize.SMALL);;
-	private final static int POSTER_HEIGHT = (int)(POSTER_WIDTH * ThumbSize.POSTER_AR);
-	private final static Rect POSTER_RECT = new Rect(0, 0, POSTER_WIDTH, POSTER_HEIGHT);
-	
 	public FlexibleItemView(Context context, IManager manager, int width, Bitmap defaultCover, Drawable selection, boolean fixedSize) {
 		super(context, manager, width, defaultCover, selection, fixedSize);
 	}
 
-	@Override
-	protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
-		if (mCover == null) {
-			setMeasuredDimension(mWidth, POSTER_HEIGHT);
-		} else {
-			setMeasuredDimension(mWidth, mCover.getHeight());
-		}
-	}
 
 	protected void onDraw(Canvas canvas) {
 		if (mCover != null && !mCover.isRecycled()) {
-			Dimension renderDim = ThumbSize.getDimension(ThumbSize.SMALL, MediaType.VIDEO, mCover.getWidth(), mCover.getHeight());
+			Dimension renderDim = ThumbSize.getTargetDimension(ThumbSize.SMALL, MediaType.VIDEO, mCover.getWidth(), mCover.getHeight());
 			drawPoster(canvas, renderDim.x, renderDim.y, mWidth);
 			drawPosterOverlay(canvas, renderDim.x, renderDim.y);
 			switch (renderDim.format) {

--- a/src/org/xbmc/api/type/ThumbSize.java
+++ b/src/org/xbmc/api/type/ThumbSize.java
@@ -38,6 +38,7 @@ public abstract class ThumbSize {
 	public static final double POSTER_AR = 1.4799154334038054968287526427061;
 	public static final double LANDSCAPE_AR = 0.5625;
 	public static final double BANNER_AR = 0.1846965699208443;
+	public static final double FULL_AR = 0.75;
 	
 	public static final int SMALL = 1;
 	public static final int MEDIUM = 2;
@@ -125,6 +126,8 @@ public abstract class ThumbSize {
 				return new Dimension(getPixel(size), getPixel(size), Dimension.SQUARE);
 			} else if (ar < 1) {			// portrait
 				return new Dimension(getPixel(size), (int)(POSTER_AR * getPixel(size)), Dimension.PORTRAIT);
+			} else if (ar < 1.5) { // landscape 4:3
+				return new Dimension((int)((double)getPixel(size) / FULL_AR), getPixel(size), Dimension.LANDSCAPE);
 			} else if (ar < 2) {			// landscape 16:9
 				return new Dimension((int)((double)getPixel(size) / LANDSCAPE_AR), getPixel(size), Dimension.LANDSCAPE);
 			} else if (ar > 5) {			// wide banner
@@ -146,90 +149,6 @@ public abstract class ThumbSize {
 				return new Dimension((int)((double)getPixel(size) / LANDSCAPE_AR), getPixel(size), Dimension.UNKNOWN);
 			}
 		}
-	}
-	
-	/**
-	 * Returns the dimensions the bitmap should be resized to before being 
-	 * cropped. Returned dimensions are with the same aspect ratio as input
-	 * parameters.
-	 * @param size      Which size
-	 * @param mediaType Which media type
-	 * @param x         Current image width
-	 * @param y         Current image height
-	 * @return
-	 */
-	public static Dimension getDimension(int size, int mediaType, int x, int y) {
-		int width = 0;
-		int height = 0;
-		int format = Dimension.UNKNOWN;
-		final double ar = ((double)x) / ((double)y);
-		switch (mediaType) {
-			default:
-			case MediaType.PICTURES:
-			case MediaType.MUSIC:
-				if (ar < 1) {
-					width = getPixel(size);
-					height = (int)((double)width / ar);
-				} else {
-					height = getPixel(size);
-					width = (int)((double)height * ar);
-				}
-				format = Dimension.SQUARE;
-				break;
-			case MediaType.VIDEO:
-			case MediaType.VIDEO_MOVIE:
-			case MediaType.VIDEO_TVEPISODE:
-			case MediaType.VIDEO_TVSEASON:
-			case MediaType.VIDEO_TVSHOW:
-				if (ar > 0.98 && ar < 1.02) { 	// square
-					if (ar < 1) {
-						width = getPixel(size);
-						height = (int)((double)width / ar);
-					} else {
-						height = getPixel(size);
-						width = (int)((double)height * ar);
-					}
-					format = Dimension.SQUARE;
-				} else if (ar < 1) {			// portrait
-					width = ThumbSize.getPixel(size);
-					final int ph = (int)(POSTER_AR * width);
-					height = (int)(width / ar); 
-					if (height < ph) { 
-						height = ph;
-						width = (int)(height * ar);
-					}
-					format = Dimension.PORTRAIT;
-				} else if (ar < 2) {			// landscape 16:9
-					height = ThumbSize.getPixel(size);
-					width = (int)(height * ar); 
-					format = Dimension.LANDSCAPE;
-				} else if (ar > 5) {			// wide banner
-					switch (size) {
-						case ThumbSize.SMALL:
-							width = ThumbSize.getPixel(ThumbSize.SCREENWIDTH);
-							height = (int)(width / ar); 
-							break;
-						case ThumbSize.MEDIUM:
-							width = ThumbSize.getPixel(ThumbSize.SCREENHEIGHT);
-							height = (int)(width / ar); 
-							break;
-						case ThumbSize.BIG:
-							height = 188;
-							width = (int)(height * ar); 
-							break;
-						default: 
-							height = -1;
-							width = -1;
-							break;
-					}
-					format = Dimension.BANNER;
-				} else {						// anything between wide banner and landscape 16:9
-					height = ThumbSize.getPixel(size);
-					width = (int)(height * ar); 
-				}
-				break;
-		}
-		return new Dimension(width, height, format);
 	}
 	
 	public static int[] values() {

--- a/src/org/xbmc/httpapi/client/Client.java
+++ b/src/org/xbmc/httpapi/client/Client.java
@@ -119,7 +119,7 @@ abstract class Client {
 				
 				if (bytes.length > 0) {
 					final BitmapFactory.Options opts = prefetch(manager, bytes, size);
-					final Dimension dim = ThumbSize.getDimension(size, mediaType, opts.outWidth, opts.outHeight);
+					final Dimension dim = ThumbSize.getTargetDimension(size, mediaType, opts.outWidth, opts.outHeight);
 					final int ss = ImportUtilities.calculateSampleSize(opts, dim);
 					opts.inDither = true;
 					opts.inSampleSize = ss;
@@ -165,14 +165,14 @@ abstract class Client {
 			
 			Log.i(TAG, "Starting download (" + url + ") - microhttpd");
 			BitmapFactory.Options opts = prefetch(manager, url, size);
-			Dimension dim = ThumbSize.getDimension(size, mediaType, opts.outWidth, opts.outHeight);
+			Dimension dim = ThumbSize.getTargetDimension(size, mediaType, opts.outWidth, opts.outHeight);
 			
 			Log.i(TAG, "Pre-fetch: " + opts.outWidth + "x" + opts.outHeight + " => " + dim);
 			if (opts.outWidth < 1) {
 				if (fallbackUrl != null) {
 					Log.i(TAG, "Starting fallback download (" + fallbackUrl + ")");
 					opts = prefetch(manager, fallbackUrl, size);
-					dim = ThumbSize.getDimension(size, mediaType, opts.outWidth, opts.outHeight);
+					dim = ThumbSize.getTargetDimension(size, mediaType, opts.outWidth, opts.outHeight);
 					Log.i(TAG, "FALLBACK-Pre-fetch: " + opts.outWidth + "x" + opts.outHeight + " => " + dim);
 					if (opts.outWidth < 1) {
 						return null;

--- a/src/org/xbmc/jsonrpc/client/Client.java
+++ b/src/org/xbmc/jsonrpc/client/Client.java
@@ -92,14 +92,14 @@ public abstract class Client {
 			Log.i(TAG, "Starting download (" + url + ")");
 			
 			BitmapFactory.Options opts = prefetch(manager, url, size, mediaType);
-			Dimension dim = ThumbSize.getDimension(size, mediaType, opts.outWidth, opts.outHeight);
+			Dimension dim = ThumbSize.getTargetDimension(size, mediaType, opts.outWidth, opts.outHeight);
 			
 			Log.i(TAG, "Pre-fetch: " + opts.outWidth + "x" + opts.outHeight + " => " + dim);
 			if (opts.outWidth < 0) {
 				if (fallbackUrl != null) {
 					Log.i(TAG, "Starting fallback download (" + fallbackUrl + ")");
 					opts = prefetch(manager, fallbackUrl, size, mediaType);
-					dim = ThumbSize.getDimension(size, mediaType, opts.outWidth, opts.outHeight);
+					dim = ThumbSize.getTargetDimension(size, mediaType, opts.outWidth, opts.outHeight);
 					Log.i(TAG, "FALLBACK-Pre-fetch: " + opts.outWidth + "x" + opts.outHeight + " => " + dim);
 					if (opts.outWidth < 0) {
 						return null;


### PR DESCRIPTION
Use centre crop to get the original thumbs in target aspect ratio before resizing
- this makes all images normalized by their aspect ratio, looks better in listview
  Add code to handle 4:3 images in getTargetDimensions method
  Remove the (now) redundant getDimensions menthod
