### PR TITLE
Leading or trailing spaces in host address during host configuration

### DIFF
--- a/src/org/xbmc/android/remote/presentation/controller/FileListController.java
+++ b/src/org/xbmc/android/remote/presentation/controller/FileListController.java
@@ -111,8 +111,8 @@ public class FileListController extends ListController implements IController {
 						mActivity.startActivity(nextActivity);
 					} else {
 						switch(item.mediaType) {
-							case 0:
-								break;
+//							case 0:
+//								break;
 							
 							case MediaType.PICTURES:
 								mControlManager.showPicture(new DataResponse<Boolean>() {

--- a/src/org/xbmc/android/remote/presentation/controller/HostPreference.java
+++ b/src/org/xbmc/android/remote/presentation/controller/HostPreference.java
@@ -193,7 +193,7 @@ public class HostPreference extends DialogPreference {
 		if (positiveResult) {
 			final Host host = new Host();
 			host.name = mNameView.getText().toString();
-			host.addr = mHostView.getText().toString();
+			host.addr = mHostView.getText().toString().trim();
 			try {
 				host.port = Integer.parseInt(mPortView.getText().toString());
 			} catch (NumberFormatException e) {


### PR DESCRIPTION
During host configuration I faced the problem, that I accidently typed a trailing whitespace character after the host name. This caused a exception when trying to connect to the XBMC server. I just added .trim() to the host address field to remove leading and trailing spaces from the host name.
