### PR TITLE
Don't poll XBMC for "Now playing" info if screen is off.

### DIFF
--- a/src/org/xbmc/android/remote/business/receiver/AndroidBroadcastReceiver.java
+++ b/src/org/xbmc/android/remote/business/receiver/AndroidBroadcastReceiver.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import org.xbmc.android.remote.R;
 import org.xbmc.android.remote.business.Command;
 import org.xbmc.android.remote.business.ManagerFactory;
+import org.xbmc.android.remote.presentation.activity.NowPlayingNotificationManager;
 import org.xbmc.android.util.SmsMmsMessage;
 import org.xbmc.android.util.SmsPopupUtils;
 import org.xbmc.api.business.DataResponse;
@@ -146,7 +147,11 @@ public class AndroidBroadcastReceiver extends BroadcastReceiver {
 								eventClient.sendNotification("SMS Received from " + msg.getContactName(), msg.getMessageBody());
 						}
 					}
-				}
+                } else if (action.equals(Intent.ACTION_SCREEN_OFF) && prefs.getBoolean("setting_show_notification", false)) {
+                    NowPlayingNotificationManager.getInstance(context).stopNotificating();
+                } else if (action.equals(Intent.ACTION_SCREEN_ON) && prefs.getBoolean("setting_show_notification", false)) {
+                    NowPlayingNotificationManager.getInstance(context).startNotificating();
+                }
 			} catch (NotFoundException e) {
 				// TODO Auto-generated catch block
 				e.printStackTrace();

--- a/src/org/xbmc/android/remote/presentation/activity/HomeActivity.java
+++ b/src/org/xbmc/android/remote/presentation/activity/HomeActivity.java
@@ -24,6 +24,7 @@ package org.xbmc.android.remote.presentation.activity;
 import org.xbmc.android.remote.R;
 import org.xbmc.android.remote.business.CacheManager;
 import org.xbmc.android.remote.business.ManagerFactory;
+import org.xbmc.android.remote.business.receiver.AndroidBroadcastReceiver;
 import org.xbmc.android.remote.presentation.controller.HomeController;
 import org.xbmc.android.remote.presentation.controller.HomeController.ProgressThread;
 import org.xbmc.android.util.KeyTracker.Stage;
@@ -37,6 +38,7 @@ import android.app.AlertDialog;
 import android.app.Dialog;
 import android.app.ProgressDialog;
 import android.content.DialogInterface;
+import android.content.IntentFilter;
 import android.content.DialogInterface.OnCancelListener;
 import android.content.Intent;
 import android.os.Build;
@@ -113,6 +115,13 @@ public class HomeActivity extends Activity {
 				startActivity(new Intent(HomeActivity.this, AboutActivity.class));
 			}
 		});
+
+        // Listen for screen on and off broadcasts
+        IntentFilter filter = new IntentFilter();
+        filter.addAction(Intent.ACTION_SCREEN_OFF);
+        filter.addAction(Intent.ACTION_SCREEN_ON);
+
+        registerReceiver(new AndroidBroadcastReceiver(), filter);
 	}
 	
 


### PR DESCRIPTION
If the user wants "Now playing" info to appear in their notification
area, make sure we don't poll XBMC every second while the screen is off,
as any new information cannot be seen until the screen is turned back on
anyway.
