### PR TITLE
"Play on XBMC" no longer shows up in apps that used to support it

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -65,6 +65,13 @@
 				<data android:scheme="http" android:mimeType="image/*"/>
 				<data android:scheme="http" android:mimeType="video/*"/>
 				<data android:scheme="http" android:mimeType="audio/*"/>
+			</intent-filter>
+		</activity>
+		<activity android:name=".presentation.activity.MediaIntentActivity" android:theme="@android:style/Theme.NoTitleBar" android:label="@string/play_on_xbmc">
+			<intent-filter>
+				<action android:name="android.intent.action.VIEW" />
+				<category android:name="android.intent.category.DEFAULT" />
+				<category android:name="android.intent.category.BROWSABLE" />
 				<data android:scheme="http" android:host="youtube.com"/>
 				<data android:scheme="http" android:host="www.youtube.com"/>
 			</intent-filter>


### PR DESCRIPTION
On recent build, apps that launch a video player no longer show "Play on XBMC" as an option in their pop-up menus.

Some looking around shows this is related to changes to the intent-filters in AndroidManifest.xml .
I don't know exactly why, but reverting part of commit 503c1d265c77fe94101cc1283e302455bcb6e6cf 's changes to AndroidManifest.xml resolves the problem, the apps show "Play on XBMC" in their pop-up menus again.

A few affected apps:
- Gemist! (Dutch app)
- TVGids.nl 2.0 (Dutch app)

There are probably more. YouTube is not affected.
