### PR TITLE
Option to queue whole album on play song

### DIFF
--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -103,6 +103,12 @@
 			android:entries="@array/SelectionPreferenceEntries"
 			android:entryValues="@array/SelectionPreferenceValues"
 			android:defaultValue="0" />
+		<CheckBoxPreference
+			android:key="setting_auto_queue_album"
+			android:title="Auto queue album"
+			android:summary="When playing a song (or queuing one when playlist is empty), if the song belong to an album, play the whole album, starting with the selected song."
+			android:selectable="true"
+			android:enabled="true" android:defaultValue="true" />	
 	</PreferenceCategory>
 	<PreferenceCategory android:title="Remote Keypress">
 		<CheckBoxPreference

--- a/src/org/xbmc/android/remote/business/MusicManager.java
+++ b/src/org/xbmc/android/remote/business/MusicManager.java
@@ -309,8 +309,12 @@ public class MusicManager extends AbstractManager implements IMusicManager, ISor
 	 */
 	public void addToPlaylist(final DataResponse<Boolean> response, final Song song, final Context context) {
 		mHandler.post(new Command<Boolean>(response, this) {
-			public void doRun() throws Exception{ 
+			public void doRun() throws Exception{
+				final IMusicClient mc = music(context);
+				final IControlClient cc = control(context);
+				final int numAlreadyQueued = mc.getPlaylistSize(MusicManager.this);
 				response.value = music(context).addToPlaylist(MusicManager.this, song);
+				checkForPlayAfterQueue(mc, cc, numAlreadyQueued);
 			}
 		});
 	}

--- a/src/org/xbmc/android/remote/presentation/controller/SongListController.java
+++ b/src/org/xbmc/android/remote/presentation/controller/SongListController.java
@@ -79,6 +79,8 @@ public class SongListController extends ListController implements IController {
 	private static final String PREF_DEFAULT_SELECTION_ACTION = "setting_default_selection_action";
 	private static final String DEFAULT_ACTION_PLAY = "0";	
 	
+	private static final String PREF_AUTO_QUEUE_ALBUM = "setting_auto_queue_album";
+	
 	private static final int INT_DEFAULT_ACTION_PLAY = 0;
 	private static final int INT_DEFAULT_ACTION_QUEUE = 1;	
 	
@@ -124,31 +126,10 @@ public class SongListController extends ListController implements IController {
 					final int SelectionType = Integer.parseInt(prefs.getString(PREF_DEFAULT_SELECTION_ACTION, DEFAULT_ACTION_PLAY));
 					switch (SelectionType) {
 						case INT_DEFAULT_ACTION_PLAY:
-							if (mAlbum == null) {
-								mMusicManager.play(new QueryResponse(
-									mActivity, 
-									"Playing \"" + song.title + "\" by " + song.artist + "...", 
-									"Error playing song!",
-									true
-								), song, mActivity.getApplicationContext());
-							} else {
-								mMusicManager.play(new QueryResponse(
-									mActivity, 
-									"Playing album \"" + song.album + "\" starting with song \"" + song.title + "\" by " + song.artist + "...",
-									"Error playing song!",
-									true
-								), mAlbum, song, mActivity.getApplicationContext());
-							}
+							playSongAlbum(song);
 							break;
-						case INT_DEFAULT_ACTION_QUEUE:					
-							if (mAlbum == null) 
-							{
-								mMusicManager.addToPlaylist(new QueryResponse(mActivity, "Song added to playlist.", "Error adding song!"), song, mActivity.getApplicationContext());
-							} 
-							else 
-							{
-								mMusicManager.addToPlaylist(new QueryResponse(mActivity, "Playlist empty, added whole album.", "Song added to playlist."), mAlbum, song, mActivity.getApplicationContext());
-							}
+						case INT_DEFAULT_ACTION_QUEUE:
+							queueSongAlbum(song);
 							break;
 						default:
 							return;
@@ -160,7 +141,7 @@ public class SongListController extends ListController implements IController {
 			fetch();
 		}
 	}
-	
+		
 	private void fetch() {
 		final String title = mAlbum != null ? mAlbum.name + " - " : mArtist != null ? mArtist.name + " - " : mGenre != null ? mGenre.name + " - " : "" + "Songs";
 		DataResponse<ArrayList<Song>> response = new DataResponse<ArrayList<Song>>() {
@@ -200,28 +181,10 @@ public class SongListController extends ListController implements IController {
 		final Song song = (Song)mList.getAdapter().getItem(((ThreeLabelsItemView)((AdapterContextMenuInfo)item.getMenuInfo()).targetView).position);
 		switch (item.getItemId()) {
 			case ITEM_CONTEXT_QUEUE:
-				if (mAlbum == null) {
-					mMusicManager.addToPlaylist(new QueryResponse(mActivity, "Song added to playlist.", "Error adding song!"), song, mActivity.getApplicationContext());
-				} else {
-					mMusicManager.addToPlaylist(new QueryResponse(mActivity, "Playlist empty, added whole album.", "Song added to playlist."), mAlbum, song, mActivity.getApplicationContext());
-				}
+				queueSongAlbum(song);
 				break;
 			case ITEM_CONTEXT_PLAY:
-				if (mAlbum == null) {
-					mMusicManager.play(new QueryResponse(
-						mActivity, 
-						"Playing \"" + song.title + "\" by " + song.artist + "...", 
-						"Error playing song!",
-						true
-					), song, mActivity.getApplicationContext());
-				} else {
-					mMusicManager.play(new QueryResponse(
-						mActivity, 
-						"Playing album \"" + song.album + "\" starting with song \"" + song.title + "\" by " + song.artist + "...",
-						"Error playing song!",
-						true
-					), mAlbum, song, mActivity.getApplicationContext());
-				}
+				playSongAlbum(song);
 				break;
 			default:
 				return;
@@ -384,5 +347,48 @@ public class SongListController extends ListController implements IController {
 		}
 	}
 	
+	/**
+	 * Plays a song or its album
+	 * if song belong to an album and "auto queue album" set, play the full album (starting with selected song).
+	 * Else play only the given song.
+	 * @param song Song to play
+	 */
+	private void playSongAlbum(Song song) {
+		final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(mActivity.getApplicationContext());
+		boolean queueAlbum = prefs.getBoolean(PREF_AUTO_QUEUE_ALBUM, true);
+		if (mAlbum == null || queueAlbum == false) {
+			mMusicManager.play(new QueryResponse(
+				mActivity, 
+				"Playing \"" + song.title + "\" by " + song.artist + "...", 
+				"Error playing song!",
+				true
+			), song, mActivity.getApplicationContext());
+		} else {
+			mMusicManager.play(new QueryResponse(
+				mActivity, 
+				"Playing album \"" + song.album + "\" starting with song \"" + song.title + "\" by " + song.artist + "...",
+				"Error playing song!",
+				true
+			), mAlbum, song, mActivity.getApplicationContext());
+		}
+	}
+		
+	/**
+	 * Queue a song or play its album
+	 * If playlist is not empty, queue the song.
+	 * Else if song belong to an album and "auto queue album" set, play the full album (starting with selected song).
+	 * Else play only the given song.
+	 * @param song Song to play
+	 */
+	private void queueSongAlbum(Song song) {
+		final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(mActivity.getApplicationContext());
+		boolean queueAlbum = prefs.getBoolean(PREF_AUTO_QUEUE_ALBUM, true);
+		if (mAlbum == null || queueAlbum == false) {
+			mMusicManager.addToPlaylist(new QueryResponse(mActivity, "Song added to playlist.", "Error adding song!"), song, mActivity.getApplicationContext());
+		} else { 
+			mMusicManager.addToPlaylist(new QueryResponse(mActivity, "Playlist empty, added whole album.", "Song added to playlist."), mAlbum, song, mActivity.getApplicationContext());
+		}
+	}
+
 	private static final long serialVersionUID = 755529227668553163L;
 }


### PR DESCRIPTION
When we play a song, if it belong to an album, the whole album is queue in the playlist.
With this feature, there is no way to add only one song in the playlist.
And then, we can't create a playlist manually. (i.e. with only some selected songs in it)

This patch add an option to enable/disable this feature. This option is activated by default so xbmc-remote still have the same behavior by default.
