### PR TITLE
Fix for Runtime of movies displayed in seconds

### DIFF
--- a/src/org/xbmc/api/object/Movie.java
+++ b/src/org/xbmc/api/object/Movie.java
@@ -66,7 +66,8 @@ public class Movie implements ICoverArt, Serializable, INamedResource {
 		this.title = detail.title;
 		this.year = detail.year;
 		this.director = detail.director;
-		this.runtime = Integer.toString(detail.runtime);
+		// runtime is in minutes
+		this.runtime = Integer.toString(detail.runtime / 60);
 		this.genres = detail.genre;
 		this.rating = detail.rating;
 		this.localPath = "";


### PR DESCRIPTION
This simply divides by 60. It appears to be the exact same behavior as Eden. 

https://github.com/freezy/android-xbmcremote/issues/58

Not quite sure why the duration doesn't match the now playing numbers, but the behavior matches between Eden and Frodo currently.
