### PR TITLE
Possible fix for null context on resume

### DIFF
--- a/src/org/xbmc/android/remote/business/NowPlayingPollerThread.java
+++ b/src/org/xbmc/android/remote/business/NowPlayingPollerThread.java
@@ -116,6 +116,9 @@ public class NowPlayingPollerThread extends Thread {
 		};
 		mSubscribers = new HashSet<Handler>();
 	}
+	public Context getApplicationContext() {
+		return mControllerStub.getApplicationContext();
+	}
 	public void subscribe(final Handler handler) {
 		// update handler on the state of affairs
 		ManagerFactory.getControlManager(mControllerStub).getCurrentlyPlaying(new DataResponse<ICurrentlyPlaying>() {

--- a/src/org/xbmc/android/util/ConnectionFactory.java
+++ b/src/org/xbmc/android/util/ConnectionFactory.java
@@ -115,13 +115,9 @@ public class ConnectionFactory {
 	 * @return A reference to the NowPlaying Poller
 	 */
 	public static NowPlayingPollerThread getNowPlayingPoller(Context context) {
-		if (sNowPlayingPoller == null) {
+		if (sNowPlayingPoller == null || !sNowPlayingPoller.isAlive() || sNowPlayingPoller.getApplicationContext() != context) {
 			sNowPlayingPoller = new NowPlayingPollerThread(context);
 			sNowPlayingPoller.start();
-		}
-		if (!sNowPlayingPoller.isAlive()){
-			sNowPlayingPoller = new NowPlayingPollerThread(context);
-			sNowPlayingPoller.start();			
 		}
 		return sNowPlayingPoller;
 	}


### PR DESCRIPTION
Happened on several occasions with current master code but cannot be reliably reproduced. The stack trace always looks exactly the same:

USER_COMMENT=null
ANDROID_VERSION=4.1.2
APP_VERSION_NAME=0.9.0
BRAND=Google
PHONE_MODEL=Nexus S
CUSTOM_DATA=
STACK_TRACE=java.lang.RuntimeException: Unable to resume activity
{org.xbmc.android.remote/org.xbmc.android.remote.presentation.activity.NowPlayingActivity}:
java.lang.NullPointerException
android.app.ActivityThread.performResumeActivity(ActivityThread.java:2701)
android.app.ActivityThread.handleResumeActivity(ActivityThread.java:2729)
android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2215)

Caused by: java.lang.NullPointerException
at android.content.ComponentName.<init>(ComponentName.java:75)
at android.content.Intent.<init>(Intent.java:3324)
org.xbmc.android.jsonrpc.io.ConnectionManager.bindService(ConnectionManager.java:221)
org.xbmc.android.jsonrpc.io.ConnectionManager.call(ConnectionManager.java:161)
org.xbmc.android.remote.business.cm.AbstractManager.callRaw(AbstractManager.java:112)
org.xbmc.android.remote.business.cm.ControlManager.getCurrentlyPlaying(ControlManager.java:154)
org.xbmc.android.remote.business.NowPlayingPollerThread.subscribe(NowPlayingPollerThread.java:121)
org.xbmc.android.remote.presentation.controller.NowPlayingController.onActivityResume(NowPlayingController.java:218)
org.xbmc.android.remote.presentation.activity.NowPlayingActivity.onResume(NowPlayingActivity.java:260)
android.app.Instrumentation.callActivityOnResume(Instrumentation.java:1184)
