### PR TITLE
The Artists list does not get sorted

### DIFF
--- a/src/org/xbmc/jsonrpc/client/MusicClient.java
+++ b/src/org/xbmc/jsonrpc/client/MusicClient.java
@@ -405,6 +405,7 @@ public class MusicClient extends Client implements IMusicClient {
 	public ArrayList<Artist> getArtists(INotifiableManager manager, ObjNode obj, boolean albumArtistsOnly) {
 		
 		obj.p(PARAM_PROPERTIES, arr().add("thumbnail")).p("albumartistsonly", albumArtistsOnly);
+		obj = sort(obj, SortType.ARTIST, "descending");
 		final ArrayList<Artist> artists = new ArrayList<Artist>();
 		final JsonNode result = mConnection.getJson(manager, "AudioLibrary.GetArtists", obj);
 		if(result != null){


### PR DESCRIPTION
After adding a new album (and the corresponding artist) to the library the artist shows up in the artists list of the xbmc remote, but is put at the bottom. This results in an unsorted list which is not convenient to use.  In xbmc 12.1 (latest stable version of Openelec on Raspberry pi) that I am using they are sorted properly.

I have cleared the cache of the app, but this does not fix the issue. The artists keep being sorted based on the moment they were added to the library rather than based on their name.
