### PR TITLE
Runtime of movies displayed in seconds

### DIFF
--- a/src/org/xbmc/jsonrpc/client/VideoClient.java
+++ b/src/org/xbmc/jsonrpc/client/VideoClient.java
@@ -21,11 +21,8 @@
 
 package org.xbmc.jsonrpc.client;
 
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.Iterator;
-import java.util.Locale;
 
 import org.codehaus.jackson.JsonNode;
 import org.xbmc.api.business.INotifiableManager;

--- a/src/org/xbmc/jsonrpc/client/VideoClient.java
+++ b/src/org/xbmc/jsonrpc/client/VideoClient.java
@@ -21,8 +21,11 @@
 
 package org.xbmc.jsonrpc.client;
 
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.Iterator;
+import java.util.Locale;
 
 import org.codehaus.jackson.JsonNode;
 import org.xbmc.api.business.INotifiableManager;
@@ -93,6 +96,15 @@ public class VideoClient extends Client implements IVideoClient {
 				if(playcount > 0 && hideWatched)
 					continue;
 				
+				int runtime = getInt(jsonMovie, "runtime");
+				String formatted_runtime = "";
+				if(runtime != -1){						
+					if(runtime >= 3600)
+						formatted_runtime = (runtime / 3600) + "hr ";
+					formatted_runtime += ((runtime % 3600) / 60) + "min";					
+				}
+				
+				
 				movies.add(new Movie(
 					getInt(jsonMovie, "movieid"),
 					getString(jsonMovie, "label"),
@@ -100,7 +112,7 @@ public class VideoClient extends Client implements IVideoClient {
 					"",
 					getString(jsonMovie, "file"),
 					getString(jsonMovie, "director"),
-					getString(jsonMovie, "runtime"),
+					formatted_runtime,
 					getString(jsonMovie, "genre"),
 					getDouble(jsonMovie, "rating"),
 					playcount,


### PR DESCRIPTION
The runtime of movies/videos is displayed in seconds and not converted to a more human readable format. I don't have a link to the PR in XBMC at hand that changed that behavior - but returning the runtime in seconds instead of the raw unparsed string is new in Frodo.
