### PR TITLE
Fix "Shutdown" not working & fix NPE in Pictures

### DIFF
--- a/src/org/xbmc/android/remote/business/ControlManager.java
+++ b/src/org/xbmc/android/remote/business/ControlManager.java
@@ -302,4 +302,18 @@ public class ControlManager extends AbstractManager implements IControlManager, 
 			}
 		});
 	}
+
+	/**
+	 * Powers off the system.
+	 * @param response Response object
+	 * @param context Context reference
+	 */
+	public void powerOff(final DataResponse<Boolean> response, final Context context) {
+		mHandler.post(new Command<Boolean>(response, this) {
+			@Override
+			public void doRun() throws Exception {
+				response.value = control(context).powerOff(ControlManager.this);
+			}
+		});
+	}
 }

--- a/src/org/xbmc/android/remote/presentation/controller/HomeController.java
+++ b/src/org/xbmc/android/remote/presentation/controller/HomeController.java
@@ -46,6 +46,7 @@ import org.xbmc.android.util.PowerDown;
 import org.xbmc.android.util.WakeOnLan;
 import org.xbmc.android.util.WifiHelper;
 import org.xbmc.api.business.DataResponse;
+import org.xbmc.api.business.IControlManager;
 import org.xbmc.api.business.IInfoManager;
 import org.xbmc.api.business.IMusicManager;
 import org.xbmc.api.business.INotifiableManager;
@@ -83,17 +84,17 @@ import android.preference.PreferenceManager;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
+import android.view.View.OnClickListener;
 import android.view.ViewGroup;
 import android.view.WindowManager;
-import android.view.View.OnClickListener;
 import android.widget.AdapterView;
+import android.widget.AdapterView.OnItemClickListener;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
 import android.widget.GridView;
 import android.widget.ImageView;
 import android.widget.TextView;
 import android.widget.Toast;
-import android.widget.AdapterView.OnItemClickListener;
 
 public class HomeController extends AbstractController implements INotifiableController, IController, Observer, OnSharedPreferenceChangeListener {
 	
@@ -317,7 +318,8 @@ public class HomeController extends AbstractController implements INotifiableCon
 						}
 						break;
 					case HOME_ACTION_POWERDOWN:
-						PowerDown powerdown = new PowerDown();
+						final IControlManager cm = ManagerFactory.getControlManager(HomeController.this);
+						PowerDown powerdown = new PowerDown(cm);
 						powerdown.ShowDialog(mActivity);
 						break;
 				}

--- a/src/org/xbmc/android/util/PowerDown.java
+++ b/src/org/xbmc/android/util/PowerDown.java
@@ -21,9 +21,9 @@
 
 package org.xbmc.android.util;
 
-import org.xbmc.android.remote.business.EventClientManager;
+import org.xbmc.api.business.DataResponse;
+import org.xbmc.api.business.IControlManager;
 import org.xbmc.api.business.IEventClientManager;
-import org.xbmc.eventclient.ButtonCodes;
 
 import android.app.Activity;
 import android.app.AlertDialog;
@@ -32,8 +32,13 @@ import android.content.DialogInterface;
 public class PowerDown {
 	IEventClientManager mEventClientManager;
 	private Activity mActivity;
+	private final IControlManager cm;
 
-	public void ShowDialog(Activity activity) {
+	public PowerDown(IControlManager cm) {
+		this.cm = cm;
+	}
+
+	public void ShowDialog(final Activity activity) {
 		mActivity = activity;
 		AlertDialog.Builder builder = new AlertDialog.Builder(mActivity);
 		builder.setMessage("Are you sure you want to power off?").setCancelable(false);
@@ -44,9 +49,7 @@ public class PowerDown {
 			}
 
 			private void Down() {
-				EventClientManager pdEventClientManager = new EventClientManager();
-				pdEventClientManager.sendButton("R1", ButtonCodes.REMOTE_POWER, false, true, true, (short) 0, (byte) 0);
-
+				cm.powerOff(new DataResponse<Boolean>(), activity.getApplicationContext());
 			}
 		}).setNegativeButton("No", new DialogInterface.OnClickListener() {
 			public void onClick(DialogInterface dialog, int id) {

--- a/src/org/xbmc/api/business/IControlManager.java
+++ b/src/org/xbmc/api/business/IControlManager.java
@@ -180,4 +180,11 @@ public interface IControlManager extends IManager {
 	 * @return true on success, false otherwise.
 	 */
 	public void sendText(final DataResponse<Boolean> response, final String text, final Context context);
+
+	/**
+	 * Powers off the system.
+	 * @param response Response object
+	 * @param context Context reference
+	 */
+	public void powerOff(final DataResponse<Boolean> response, final Context context);
 }

--- a/src/org/xbmc/api/data/IControlClient.java
+++ b/src/org/xbmc/api/data/IControlClient.java
@@ -75,6 +75,13 @@ public interface IControlClient extends IClient {
 	public boolean pause(INotifiableManager manager);
 	
 	/**
+	 * Powers off the system.
+	 * @param manager Manager reference
+	 * @return true on success, false otherwise.
+	 */
+	public boolean powerOff(INotifiableManager manager);
+
+	/**
 	 * Stops the currently playing media. 
 	 * @param manager Manager reference
 	 * @return true on success, false otherwise.
@@ -101,7 +108,7 @@ public interface IControlClient extends IClient {
 	 * Seeks to a position. If type is
 	 * <ul>
 	 * 	<li><code>absolute</code> - Sets the playing position of the currently 
-	 *		playing media as a percentage of the media�s length.</li>
+	 *		playing media as a percentage of the media's length.</li>
 	 *  <li><code>relative</code> - Adds/Subtracts the current percentage on to
 	 *		the current position in the song</li>
 	 * </ul> 

--- a/src/org/xbmc/httpapi/client/ControlClient.java
+++ b/src/org/xbmc/httpapi/client/ControlClient.java
@@ -175,7 +175,7 @@ public class ControlClient implements IControlClient {
 	 * Seeks to a position. If type is
 	 * <ul>
 	 * 	<li><code>absolute</code> - Sets the playing position of the currently 
-	 *		playing media as a percentage of the media�s length.</li>
+	 *		playing media as a percentage of the media's length.</li>
 	 *  <li><code>relative</code> - Adds/Subtracts the current percentage on to
 	 *		the current position in the song</li>
 	 * </ul> 
@@ -478,5 +478,14 @@ public class ControlClient implements IControlClient {
 					return nothingPlaying;
 			}
 		}
+	}
+
+	/**
+	 * Powers off the system.
+	 * @param response Response object
+	 * @return true on success, false otherwise.
+	 */
+	public boolean powerOff(INotifiableManager manager) {
+		return mConnection.getBoolean(manager, "Shutdown()");
 	}
 }

--- a/src/org/xbmc/jsonrpc/client/ControlClient.java
+++ b/src/org/xbmc/jsonrpc/client/ControlClient.java
@@ -126,6 +126,15 @@ public class ControlClient extends Client implements IControlClient {
 	}
 	
 	/**
+	 * Powers off the system.
+	 * @param manager Manager reference
+	 * @return OK on success, false otherwise.
+	 */
+	public boolean powerOff(INotifiableManager manager) {
+		return mConnection.getString(manager, "System.Shutdown", null).equals("OK");
+	}
+
+	/**
 	 * Start playing the media file at the given URL
 	 * @param manager Manager reference
 	 * @param url An URL pointing to a supported media file

--- a/src/org/xbmc/jsonrpc/client/InfoClient.java
+++ b/src/org/xbmc/jsonrpc/client/InfoClient.java
@@ -74,11 +74,9 @@ public class InfoClient extends Client implements IInfoClient {
 	 * @return
 	 */
 	public ArrayList<FileLocation> getShares(INotifiableManager manager, int mediaType) {
-		
-
 		final ArrayList<FileLocation> shares = new ArrayList<FileLocation>();
 		final JsonNode jsonShares = mConnection.getJson(manager, "Files.GetSources", obj().p("media", MediaType.getName(mediaType)));
-		if(jsonShares != null){
+		if(jsonShares != null && jsonShares.get("sources") != null) {
 			for (Iterator<JsonNode> i = jsonShares.get("sources").getElements(); i.hasNext();) {
 				JsonNode jsonShare = (JsonNode)i.next();
 				shares.add(new FileLocation(getString(jsonShare, "label"), getString(jsonShare, "file")));


### PR DESCRIPTION
Shutdown uses the EventServer and this brings up the shutdown
dialog where you need to choose what to do. This behaviour is not
inline with what we experience on iOS client and makes it hard to
shut down a system from remote as the selection might end up in
dialog close or the first item. Convert the call to JSON-RPC
instead. This will gracefully shutdown the XBMC server and power
off the system
