### PR TITLE
show action overflow in system navigation, again. Fixes #105

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -5,7 +5,7 @@
 	android:versionCode="1009" 
 	android:installLocation="auto">
 	
-	<uses-sdk android:minSdkVersion="3" android:targetSdkVersion="14" />
+	<uses-sdk android:minSdkVersion="3" android:targetSdkVersion="13" />
 	
 	<supports-screens
 		android:largeScreens="true"


### PR DESCRIPTION
If current activity doesn't use actionbar and the device doesn't have a
hardware menu button, the system must add the action overflow button
beside the system navigation, because otherwise the options become
inaccessible.
I implemented a solution based on this blogpost:
http://android-developers.blogspot.de/2012/01/say-goodbye-to-menu-button.html
[...] if you set minSdkVersion to 10 or lower, set targetSdkVersion to
11, 12, or 13, and you do not use ActionBar, the system will add the
legacy overflow button [...] if the device itself doesn't feature a
hardware menu button, thus making the options accessible.
This solves issue #105 where one could not access the options of
RemoteActivity (and others) on newer devices that don't feature a
hardware menu button (which is basically all devices except Samsung's)
