### PR TITLE
Refactor Large Class Abstract Manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /bin
 *.apk
 local.properties
+.idea/
+android-xbmcremote.iml

--- a/patches/0000-Refactor AbstractManager.patch
+++ b/patches/0000-Refactor AbstractManager.patch
@@ -1,0 +1,7 @@
+From: Corey Lee <lee.j.corey@gmail.com>
+Date: Wed, 26 Nov 2014 21:57:27 -0500
+Subject: [PATCH 0/3] 
+AbstractManager is a Large Class (Code Smell) and it has more than one responsibility.
+Therefore, we extracted Sort attributes and methods to a new class called SortPreferenceMedia.
+
+

--- a/patches/0001-Added-Preferences-For-IDE-to-Ignore-File.patch
+++ b/patches/0001-Added-Preferences-For-IDE-to-Ignore-File.patch
@@ -1,0 +1,24 @@
+From 1c5a8cad50e88000cc247cc8981c3c7eb298896c Mon Sep 17 00:00:00 2001
+From: Corey Lee <lee.j.corey@gmail.com>
+Date: Wed, 26 Nov 2014 21:57:27 -0500
+Subject: [PATCH 1/3] Added Preferences For IDE to Ignore File
+
+Added files to the .gitignore from the preferences that were created by
+Android Studio
+---
+ .gitignore | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/.gitignore b/.gitignore
+index d84c129..a60a685 100755
+--- a/.gitignore
++++ b/.gitignore
+@@ -2,3 +2,5 @@
+ /bin
+ *.apk
+ local.properties
++.idea/
++android-xbmcremote.iml
+-- 
+1.9.3 (Apple Git-50)
+

--- a/patches/0002-Refactored-AbstractManager.patch
+++ b/patches/0002-Refactored-AbstractManager.patch
@@ -1,0 +1,977 @@
+From 6c473ba3359ffcdef18df21a0ba42a579fe0ff7d Mon Sep 17 00:00:00 2001
+From: Corey Lee <lee.j.corey@gmail.com>
+Date: Wed, 26 Nov 2014 23:10:55 -0500
+Subject: [PATCH 2/3] Refactored AbstractManager
+
+- Extracted KEY_SORT attributes to a new class called
+SortPreferenceMedia
+- Removed Interface ISortableManager from the child classes of
+AbstractManager
+---
+ .../android/remote/business/AbstractManager.java   | 72 +++------------------
+ .../xbmc/android/remote/business/MusicManager.java | 38 +++++------
+ .../remote/business/SortPreferenceMedia.java       | 73 ++++++++++++++++++++++
+ .../android/remote/business/TvShowManager.java     | 21 +++----
+ .../xbmc/android/remote/business/VideoManager.java | 12 ++--
+ .../controller/AlbumListController.java            | 28 ++++-----
+ .../controller/EpisodeListController.java          | 28 ++++-----
+ .../controller/MovieListController.java            | 36 +++++------
+ .../controller/SongListController.java             | 36 +++++------
+ .../controller/TvShowListController.java           | 28 ++++-----
+ 10 files changed, 196 insertions(+), 176 deletions(-)
+ create mode 100644 src/org/xbmc/android/remote/business/SortPreferenceMedia.java
+
+diff --git a/src/org/xbmc/android/remote/business/AbstractManager.java b/src/org/xbmc/android/remote/business/AbstractManager.java
+index a73c825..a4da556 100644
+--- a/src/org/xbmc/android/remote/business/AbstractManager.java
++++ b/src/org/xbmc/android/remote/business/AbstractManager.java
+@@ -36,12 +36,10 @@ import org.xbmc.api.data.IVideoClient;
+ import org.xbmc.api.object.ICoverArt;
+ import org.xbmc.api.presentation.INotifiableController;
+ import org.xbmc.api.type.CacheType;
+-import org.xbmc.api.type.SortType;
+ import org.xbmc.api.type.ThumbSize;
+ import org.xbmc.httpapi.WifiStateException;
+ 
+ import android.content.Context;
+-import android.content.SharedPreferences;
+ import android.graphics.Bitmap;
+ import android.os.Handler;
+ import android.util.Log;
+@@ -56,31 +54,14 @@ public abstract class AbstractManager implements INotifiableManager {
+ 	public static final Boolean DEBUG = false;
+ 	
+ 	protected static final String TAG = "AbstractManager";
+-	
+-	public static final String PREF_SORT_BY_PREFIX = "sort_by_";
+-	public static final String PREF_SORT_ORDER_PREFIX = "sort_order_";
+-	
+-	/* The idea of the sort keys is to remember different sort settings for
+-	 * each type. In your controller, make sure you run setSortKey() in the
+-	 * onCreate() method.
+-	 */
+-	public static final int PREF_SORT_KEY_ALBUM = 1;
+-	public static final int PREF_SORT_KEY_ARTIST = 2;
+-	public static final int PREF_SORT_KEY_SONG = 3;
+-	public static final int PREF_SORT_KEY_GENRE = 4;
+-	public static final int PREF_SORT_KEY_FILEMODE = 5;
+-	public static final int PREF_SORT_KEY_SHOW = 6;
+-	public static final int PREF_SORT_KEY_MOVIE = 7;
+-	public static final int PREF_SORT_KEY_EPISODE = 8;
+-	
+-	protected INotifiableController mController = null;
++
++    protected final SortPreferenceMedia sortPreferenceMedia = new SortPreferenceMedia();
++
++    protected INotifiableController mController = null;
+ 	
+ 	protected Handler mHandler;
+-	
+-	protected SharedPreferences mPref;
+-	protected int mCurrentSortKey;
+-	
+-	protected List<Runnable> failedRequests = new ArrayList<Runnable>();
++
++    protected List<Runnable> failedRequests = new ArrayList<Runnable>();
+ 	/**
+ 	 * Sets the handler used in the looping thread
+ 	 * @param handler
+@@ -331,53 +312,20 @@ public abstract class AbstractManager implements INotifiableManager {
+ 			}
+ 		});
+ 	}
+-	
+-	/**
+-	 * Sets the static reference to the preferences object. Used to obtain
+-	 * current sort values.
+-	 * @param pref
+-	 */
+-	public void setPreferences(SharedPreferences pref) {
+-		mPref = pref;
+-	}
+ 
+-	/**
+-	 * Sets which kind of view is currently active.
+-	 * @param sortKey
+-	 */
+-	public void setSortKey(int sortKey) {
+-		mCurrentSortKey = sortKey;
+-	}
+-	
+-	public void post(Runnable runnable)
++    public void post(Runnable runnable)
+ 	{
+ 		mHandler.post(runnable);
+ 	}
+-	
+-	/**
+-	 * Returns currently saved "sort by" value. If the preference was not set yet, or
+-	 * if the current sort key is not set, return default value.
+-	 * @param type Default value
+-	 * @return Sort by field
+-	 */
+-	protected int getSortBy(int type) {
+-		if (mPref != null) {
+-			return mPref.getInt(PREF_SORT_BY_PREFIX + mCurrentSortKey, type);
+-		}
+-		return type;
+-	}
+-	
++
+ 	/**
+ 	 * Returns currently saved "sort by" value. If the preference was not set yet, or
+ 	 * if the current sort key is not set, return "ASC".
+ 	 * @return Sort order
+ 	 */
+ 	protected String getSortOrder() {
+-		if (mPref != null) {
+-			return mPref.getString(PREF_SORT_ORDER_PREFIX + mCurrentSortKey, SortType.ORDER_ASC);
+-		}
+-		return SortType.ORDER_ASC;
+-	}
++        return sortPreferenceMedia.getSortOrder();
++    }
+ 	
+ 	protected boolean getHideWatched(Context context) {
+ 		return context.getSharedPreferences("global", Context.MODE_PRIVATE).getBoolean("HideWatched", false);
+diff --git a/src/org/xbmc/android/remote/business/MusicManager.java b/src/org/xbmc/android/remote/business/MusicManager.java
+index 0d9e28f..277189d 100644
+--- a/src/org/xbmc/android/remote/business/MusicManager.java
++++ b/src/org/xbmc/android/remote/business/MusicManager.java
+@@ -46,7 +46,7 @@ import android.content.Context;
+  * 
+  * @author Team XBMC
+  */
+-public class MusicManager extends AbstractManager implements IMusicManager, ISortableManager, INotifiableManager {
++public class MusicManager extends AbstractManager implements IMusicManager, INotifiableManager {
+ 	
+ 	/**
+ 	 * Gets all albums from database
+@@ -71,7 +71,7 @@ public class MusicManager extends AbstractManager implements IMusicManager, ISor
+ 		mHandler.post(new Command<ArrayList<Album>>(response, this) {
+ 			@Override
+ 			public void doRun() throws Exception {
+-				response.value = music(context).getAlbums(MusicManager.this, getSortBy(SortType.ALBUM), getSortOrder());
++				response.value = music(context).getAlbums(MusicManager.this, sortPreferenceMedia.getSortBy(SortType.ALBUM), sortPreferenceMedia.getSortOrder());
+ 			}
+ 		});
+ 	}
+@@ -82,7 +82,7 @@ public class MusicManager extends AbstractManager implements IMusicManager, ISor
+ 	 */
+ 	public ArrayList<Album> getAlbums(final Context context) {
+ 		try { //TODO fix this to throw 
+-			return music(context).getAlbums(MusicManager.this, getSortBy(SortType.ALBUM), getSortOrder());
++			return music(context).getAlbums(MusicManager.this, sortPreferenceMedia.getSortBy(SortType.ALBUM), sortPreferenceMedia.getSortOrder());
+ 		} catch (WifiStateException e) {
+ 			e.printStackTrace();
+ 		}
+@@ -104,7 +104,7 @@ public class MusicManager extends AbstractManager implements IMusicManager, ISor
+ 		mHandler.post(new Command<ArrayList<Album>>(response, this){
+ 			@Override
+ 			public void doRun() throws Exception {
+-				response.value = music(context).getAlbums(MusicManager.this, artist, getSortBy(SortType.ALBUM), getSortOrder());
++				response.value = music(context).getAlbums(MusicManager.this, artist, sortPreferenceMedia.getSortBy(SortType.ALBUM), sortPreferenceMedia.getSortOrder());
+ 			}
+ 		});
+ 	}
+@@ -123,7 +123,7 @@ public class MusicManager extends AbstractManager implements IMusicManager, ISor
+ //		});
+ 		mHandler.post(new Command<ArrayList<Album>>(response, this) {
+ 			public void doRun() throws Exception{ 
+-				response.value = music(context).getAlbums(MusicManager.this, genre, getSortBy(SortType.ALBUM), getSortOrder());
++				response.value = music(context).getAlbums(MusicManager.this, genre, sortPreferenceMedia.getSortBy(SortType.ALBUM), sortPreferenceMedia.getSortOrder());
+ 			}
+ 		});
+ 	}
+@@ -142,7 +142,7 @@ public class MusicManager extends AbstractManager implements IMusicManager, ISor
+ //		});
+ 		mHandler.post(new Command<ArrayList<Song>>(response, this) {
+ 			public void doRun() throws Exception{ 
+-				response.value = music(context).getSongs(MusicManager.this, album, getSortBy(SortType.TRACK), getSortOrder());
++				response.value = music(context).getSongs(MusicManager.this, album, sortPreferenceMedia.getSortBy(SortType.TRACK), sortPreferenceMedia.getSortOrder());
+ 			}
+ 		});
+ 	}
+@@ -161,7 +161,7 @@ public class MusicManager extends AbstractManager implements IMusicManager, ISor
+ //		});
+ 		mHandler.post(new Command<ArrayList<Song>>(response, this) {
+ 			public void doRun() throws Exception{ 
+-				response.value = music(context).getSongs(MusicManager.this, artist, getSortBy(SortType.ARTIST), getSortOrder());
++				response.value = music(context).getSongs(MusicManager.this, artist, sortPreferenceMedia.getSortBy(SortType.ARTIST), sortPreferenceMedia.getSortOrder());
+ 			}
+ 		});
+ 	}
+@@ -180,7 +180,7 @@ public class MusicManager extends AbstractManager implements IMusicManager, ISor
+ //		});
+ 		mHandler.post(new Command<ArrayList<Song>>(response, this) {
+ 			public void doRun() throws Exception{ 
+-				response.value = music(context).getSongs(MusicManager.this, genre, getSortBy(SortType.ARTIST), getSortOrder());
++				response.value = music(context).getSongs(MusicManager.this, genre, sortPreferenceMedia.getSortBy(SortType.ARTIST), sortPreferenceMedia.getSortOrder());
+ 			}
+ 		});
+ 	}
+@@ -278,7 +278,7 @@ public class MusicManager extends AbstractManager implements IMusicManager, ISor
+ 				final IMusicClient mc = music(context);
+ 				final IControlClient cc = control(context);
+ 				final int numAlreadyQueued = mc.getPlaylistSize(MusicManager.this);
+-				response.value = mc.addToPlaylist(MusicManager.this, album, getSortBy(SortType.TRACK), getSortOrder());
++				response.value = mc.addToPlaylist(MusicManager.this, album, sortPreferenceMedia.getSortBy(SortType.TRACK), sortPreferenceMedia.getSortOrder());
+ 				checkForPlayAfterQueue(mc, cc, numAlreadyQueued);
+ 			}
+ 		});
+@@ -296,7 +296,7 @@ public class MusicManager extends AbstractManager implements IMusicManager, ISor
+ 				final IMusicClient mc = music(context);
+ 				final IControlClient cc = control(context);
+ 				final int numAlreadyQueued = mc.getPlaylistSize(MusicManager.this);
+-				response.value = mc.addToPlaylist(MusicManager.this, genre, getSortBy(SortType.ARTIST), getSortOrder());
++				response.value = mc.addToPlaylist(MusicManager.this, genre, sortPreferenceMedia.getSortBy(SortType.ARTIST), sortPreferenceMedia.getSortOrder());
+ 				checkForPlayAfterQueue(mc, cc, numAlreadyQueued);
+ 			}
+ 		});
+@@ -338,14 +338,14 @@ public class MusicManager extends AbstractManager implements IMusicManager, ISor
+ 				int playPos = -1;
+ 				if (playlistSize == 0) {  // if playlist is empty, add the whole album
+ 					int n = 0;
+-					for (Song albumSong : mc.getSongs(MusicManager.this, album, getSortBy(PREF_SORT_KEY_ALBUM), getSortOrder())) {
++					for (Song albumSong : mc.getSongs(MusicManager.this, album, sortPreferenceMedia.getSortBy(SortPreferenceMedia.PREF_SORT_KEY_ALBUM), sortPreferenceMedia.getSortOrder())) {
+ 						if (albumSong.id == song.id) {
+ 							playPos = n;
+ 							break;
+ 						}
+ 						n++;
+ 					}
+-					mc.addToPlaylist(MusicManager.this, album, getSortBy(PREF_SORT_KEY_ALBUM), getSortOrder());
++					mc.addToPlaylist(MusicManager.this, album, sortPreferenceMedia.getSortBy(SortPreferenceMedia.PREF_SORT_KEY_ALBUM), sortPreferenceMedia.getSortOrder());
+ 					response.value = true;
+ 				} else {                          // otherwise, only add the song
+ 					mc.addToPlaylist(MusicManager.this, song);
+@@ -381,7 +381,7 @@ public class MusicManager extends AbstractManager implements IMusicManager, ISor
+ 				final IMusicClient mc = music(context);
+ 				final IControlClient cc = control(context);
+ 				final int numAlreadyQueued = mc.getPlaylistSize(MusicManager.this);
+-				response.value = mc.addToPlaylist(MusicManager.this, artist, getSortBy(SortType.ALBUM), getSortOrder());
++				response.value = mc.addToPlaylist(MusicManager.this, artist, sortPreferenceMedia.getSortBy(SortType.ALBUM), sortPreferenceMedia.getSortOrder());
+ 				checkForPlayAfterQueue(mc, cc, numAlreadyQueued);
+ 			}
+ 		});
+@@ -400,7 +400,7 @@ public class MusicManager extends AbstractManager implements IMusicManager, ISor
+ 				final IMusicClient mc = music(context);
+ 				final IControlClient cc = control(context);
+ 				final int numAlreadyQueued = mc.getPlaylistSize(MusicManager.this);
+-				response.value = mc.addToPlaylist(MusicManager.this, artist, genre, getSortBy(SortType.ARTIST), getSortOrder());
++				response.value = mc.addToPlaylist(MusicManager.this, artist, genre, sortPreferenceMedia.getSortBy(SortType.ARTIST), sortPreferenceMedia.getSortOrder());
+ 				checkForPlayAfterQueue(mc, cc, numAlreadyQueued);
+ 			}
+ 		});
+@@ -454,7 +454,7 @@ public class MusicManager extends AbstractManager implements IMusicManager, ISor
+ 		mHandler.post(new Command<Boolean>(response, this) {
+ 			public void doRun() throws Exception{ 
+ 				control(context).stop(MusicManager.this);
+-				response.value = music(context).play(MusicManager.this, album, getSortBy(SortType.TRACK), getSortOrder());
++				response.value = music(context).play(MusicManager.this, album, sortPreferenceMedia.getSortBy(SortType.TRACK), sortPreferenceMedia.getSortOrder());
+ 			}
+ 		});
+ 	}
+@@ -468,7 +468,7 @@ public class MusicManager extends AbstractManager implements IMusicManager, ISor
+ 		mHandler.post(new Command<Boolean>(response, this) {
+ 			public void doRun() throws Exception{ 
+ 				control(context).stop(MusicManager.this);
+-				response.value = music(context).play(MusicManager.this, genre, getSortBy(SortType.ARTIST), getSortOrder());
++				response.value = music(context).play(MusicManager.this, genre, sortPreferenceMedia.getSortBy(SortType.ARTIST), sortPreferenceMedia.getSortOrder());
+ 			}
+ 		});
+ 	}
+@@ -501,7 +501,7 @@ public class MusicManager extends AbstractManager implements IMusicManager, ISor
+ 				int n = 0;
+ 				int playPos = 0;
+ 				mc.clearPlaylist(MusicManager.this);
+-				for (Song albumSong : mc.getSongs(MusicManager.this, album, getSortBy(SortType.TRACK), getSortOrder())) {
++				for (Song albumSong : mc.getSongs(MusicManager.this, album, sortPreferenceMedia.getSortBy(SortType.TRACK), sortPreferenceMedia.getSortOrder())) {
+ 					if (albumSong.id == song.id) {
+ 						playPos = n;
+ 						break;
+@@ -509,7 +509,7 @@ public class MusicManager extends AbstractManager implements IMusicManager, ISor
+ 					n++;
+ 				}
+ 				cc.stop(MusicManager.this);
+-				mc.addToPlaylist(MusicManager.this, album, getSortBy(SortType.TRACK), getSortOrder());
++				mc.addToPlaylist(MusicManager.this, album, sortPreferenceMedia.getSortBy(SortType.TRACK), sortPreferenceMedia.getSortOrder());
+ 				if (playPos > 0) {
+ 					response.value = mc.playlistSetSong(MusicManager.this, playPos);
+ 				}
+@@ -529,7 +529,7 @@ public class MusicManager extends AbstractManager implements IMusicManager, ISor
+ 		mHandler.post(new Command<Boolean>(response, this) {
+ 			public void doRun() throws Exception{ 
+ 				control(context).stop(MusicManager.this);
+-				response.value = music(context).play(MusicManager.this, artist, getSortBy(SortType.ALBUM), getSortOrder());
++				response.value = music(context).play(MusicManager.this, artist, sortPreferenceMedia.getSortBy(SortType.ALBUM), sortPreferenceMedia.getSortOrder());
+ 			}
+ 		});
+ 	}
+diff --git a/src/org/xbmc/android/remote/business/SortPreferenceMedia.java b/src/org/xbmc/android/remote/business/SortPreferenceMedia.java
+new file mode 100644
+index 0000000..f4088ee
+--- /dev/null
++++ b/src/org/xbmc/android/remote/business/SortPreferenceMedia.java
+@@ -0,0 +1,73 @@
++package org.xbmc.android.remote.business;
++
++import android.content.SharedPreferences;
++
++import org.xbmc.api.business.ISortableManager;
++import org.xbmc.api.type.SortType;
++
++public class SortPreferenceMedia implements ISortableManager {
++    public static final String PREF_SORT_BY_PREFIX = "sort_by_";
++    public static final String PREF_SORT_ORDER_PREFIX = "sort_order_";
++
++    /* The idea of the sort keys is to remember different sort settings for
++     * each type. In your controller, make sure you run setSortKey() in the
++	 * onCreate() method.
++	 */
++    public static final int PREF_SORT_KEY_ALBUM = 1;
++    public static final int PREF_SORT_KEY_ARTIST = 2;
++    public static final int PREF_SORT_KEY_SONG = 3;
++    public static final int PREF_SORT_KEY_GENRE = 4;
++    public static final int PREF_SORT_KEY_FILEMODE = 5;
++    public static final int PREF_SORT_KEY_SHOW = 6;
++    public static final int PREF_SORT_KEY_MOVIE = 7;
++    public static final int PREF_SORT_KEY_EPISODE = 8;
++
++    public SharedPreferences mPref;
++    public int mCurrentSortKey;
++
++    /**
++     * Sets the static reference to the preferences object. Used to obtain
++     * current sort values.
++     *
++     * @param pref
++     */
++    public void setPreferences(SharedPreferences pref) {
++        mPref = pref;
++    }
++
++    /**
++     * Sets which kind of view is currently active.
++     *
++     * @param sortKey
++     */
++    public void setSortKey(int sortKey) {
++        mCurrentSortKey = sortKey;
++    }
++
++    /**
++     * Returns currently saved "sort by" value. If the preference was not set yet, or
++     * if the current sort key is not set, return default value.
++     *
++     * @param type Default value
++     * @return Sort by field
++     */
++    public int getSortBy(int type) {
++        if (mPref != null) {
++            return mPref.getInt(PREF_SORT_BY_PREFIX + mCurrentSortKey, type);
++        }
++        return type;
++    }
++
++    /**
++     * Returns currently saved "sort by" value. If the preference was not set yet, or
++     * if the current sort key is not set, return "ASC".
++     *
++     * @return Sort order
++     */
++    public String getSortOrder() {
++        if (mPref != null) {
++            return mPref.getString(PREF_SORT_ORDER_PREFIX + mCurrentSortKey, SortType.ORDER_ASC);
++        }
++        return SortType.ORDER_ASC;
++    }
++}
+\ No newline at end of file
+diff --git a/src/org/xbmc/android/remote/business/TvShowManager.java b/src/org/xbmc/android/remote/business/TvShowManager.java
+index fe6411b..2354a97 100644
+--- a/src/org/xbmc/android/remote/business/TvShowManager.java
++++ b/src/org/xbmc/android/remote/business/TvShowManager.java
+@@ -16,8 +16,7 @@ import org.xbmc.httpapi.WifiStateException;
+ 
+ import android.content.Context;
+ 
+-public class TvShowManager extends AbstractManager implements ITvShowManager,
+-		ISortableManager, INotifiableManager {
++public class TvShowManager extends AbstractManager implements ITvShowManager, INotifiableManager {
+ 
+ 	/**
+ 	 * Gets all tv shows actors from database
+@@ -53,7 +52,7 @@ public class TvShowManager extends AbstractManager implements ITvShowManager,
+ 		mHandler.post(new Command<ArrayList<TvShow>>(response, this) {
+ 			@Override
+ 			public void doRun() throws Exception {
+-				response.value = shows(context).getTvShows(TvShowManager.this, getSortBy(SortType.TITLE), getSortOrder(), getHideWatched(context));
++				response.value = shows(context).getTvShows(TvShowManager.this, sortPreferenceMedia.getSortBy(SortType.TITLE), sortPreferenceMedia.getSortOrder(), getHideWatched(context));
+ 			}
+ 		});
+ 	}
+@@ -64,7 +63,7 @@ public class TvShowManager extends AbstractManager implements ITvShowManager,
+ 	 */
+ 	public ArrayList<TvShow> getTvShows(Context context) {
+ 		try {
+-			return shows(context).getTvShows(TvShowManager.this, getSortBy(SortType.TITLE), getSortOrder(), getHideWatched(context));
++			return shows(context).getTvShows(TvShowManager.this, sortPreferenceMedia.getSortBy(SortType.TITLE), sortPreferenceMedia.getSortOrder(), getHideWatched(context));
+ 		} catch (WifiStateException e) {
+ 			TvShowManager.this.onError(e);
+ 		}
+@@ -77,7 +76,7 @@ public class TvShowManager extends AbstractManager implements ITvShowManager,
+ 	 */
+ 	public ArrayList<Season> getAllSeasons(Context context) {
+ 		try {
+-			return shows(context).getSeasons(TvShowManager.this, getSortBy(SortType.TITLE), getSortOrder(), getHideWatched(context));
++			return shows(context).getSeasons(TvShowManager.this, sortPreferenceMedia.getSortBy(SortType.TITLE), sortPreferenceMedia.getSortOrder(), getHideWatched(context));
+ 		} catch (WifiStateException e) {
+ 			TvShowManager.this.onError(e);
+ 		}
+@@ -90,7 +89,7 @@ public class TvShowManager extends AbstractManager implements ITvShowManager,
+ 	 */
+ 	public ArrayList<Episode> getAllEpisodes(Context context) {
+ 		try {
+-			return shows(context).getEpisodes(TvShowManager.this, getSortBy(SortType.EPISODE_NUM), getSortOrder(), getHideWatched(context));
++			return shows(context).getEpisodes(TvShowManager.this, sortPreferenceMedia.getSortBy(SortType.EPISODE_NUM), sortPreferenceMedia.getSortOrder(), getHideWatched(context));
+ 		} catch (WifiStateException e) {
+ 			TvShowManager.this.onError(e);
+ 		}
+@@ -106,7 +105,7 @@ public class TvShowManager extends AbstractManager implements ITvShowManager,
+ 		mHandler.post(new Command<ArrayList<TvShow>>(response, this) {
+ 			@Override
+ 			public void doRun() throws Exception {
+-				response.value = shows(context).getTvShows(TvShowManager.this, genre, getSortBy(SortType.TITLE), getSortOrder(), getHideWatched(context));
++				response.value = shows(context).getTvShows(TvShowManager.this, genre, sortPreferenceMedia.getSortBy(SortType.TITLE), sortPreferenceMedia.getSortOrder(), getHideWatched(context));
+ 			}
+ 		});
+ 	}
+@@ -120,7 +119,7 @@ public class TvShowManager extends AbstractManager implements ITvShowManager,
+ 		mHandler.post(new Command<ArrayList<TvShow>>(response, this) {
+ 			@Override
+ 			public void doRun() throws Exception {
+-				mResponse.value = shows(context).getTvShows(TvShowManager.this, actor, getSortBy(SortType.TITLE), getSortOrder(), getHideWatched(context));
++				mResponse.value = shows(context).getTvShows(TvShowManager.this, actor, sortPreferenceMedia.getSortBy(SortType.TITLE), sortPreferenceMedia.getSortOrder(), getHideWatched(context));
+ 			}
+ 		});
+ 	}
+@@ -135,7 +134,7 @@ public class TvShowManager extends AbstractManager implements ITvShowManager,
+ 		mHandler.post(new Command<ArrayList<Episode>>(response, this) {
+ 			@Override
+ 			public void doRun() throws Exception {
+-				mResponse.value = shows(context).getEpisodes(TvShowManager.this, show, getSortBy(SortType.EPISODE_NUM), getSortOrder(), getHideWatched(context));
++				mResponse.value = shows(context).getEpisodes(TvShowManager.this, show, sortPreferenceMedia.getSortBy(SortType.EPISODE_NUM), sortPreferenceMedia.getSortOrder(), getHideWatched(context));
+ 			}
+ 		});
+ 	}
+@@ -166,7 +165,7 @@ public class TvShowManager extends AbstractManager implements ITvShowManager,
+ 		mHandler.post(new Command<ArrayList<Episode>>(response, this) {
+ 			@Override
+ 			public void doRun() throws Exception {
+-				mResponse.value = shows(context).getEpisodes(TvShowManager.this, show, season, getSortBy(SortType.EPISODE_NUM), getSortOrder(), getHideWatched(context));
++				mResponse.value = shows(context).getEpisodes(TvShowManager.this, show, season, sortPreferenceMedia.getSortBy(SortType.EPISODE_NUM), sortPreferenceMedia.getSortOrder(), getHideWatched(context));
+ 			}
+ 		});
+ 		
+@@ -182,7 +181,7 @@ public class TvShowManager extends AbstractManager implements ITvShowManager,
+ 		mHandler.post(new Command<ArrayList<Episode>>(response, this) {
+ 			@Override
+ 			public void doRun() throws Exception {
+-				mResponse.value = shows(context).getEpisodes(TvShowManager.this, season, getSortBy(SortType.EPISODE_NUM), getSortOrder(), getHideWatched(context));
++				mResponse.value = shows(context).getEpisodes(TvShowManager.this, season, sortPreferenceMedia.getSortBy(SortType.EPISODE_NUM), sortPreferenceMedia.getSortOrder(), getHideWatched(context));
+ 			}
+ 		});
+ 	}
+diff --git a/src/org/xbmc/android/remote/business/VideoManager.java b/src/org/xbmc/android/remote/business/VideoManager.java
+index 29c5c6e..b546561 100644
+--- a/src/org/xbmc/android/remote/business/VideoManager.java
++++ b/src/org/xbmc/android/remote/business/VideoManager.java
+@@ -40,7 +40,7 @@ import android.content.Context;
+  * 
+  * @author Team XBMC
+  */
+-public class VideoManager extends AbstractManager implements IVideoManager, ISortableManager, INotifiableManager {
++public class VideoManager extends AbstractManager implements IVideoManager, INotifiableManager {
+ 	
+ 	/**
+ 	 * Updates the movie object with additional data (plot, cast, etc)
+@@ -64,7 +64,7 @@ public class VideoManager extends AbstractManager implements IVideoManager, ISor
+ 		mHandler.post(new Command<ArrayList<Movie>>(response, this) {
+ 			@Override
+ 			public void doRun() throws Exception { 
+-				response.value = video(context).getMovies(VideoManager.this, getSortBy(SortType.TITLE), getSortOrder(), getHideWatched(context));
++				response.value = video(context).getMovies(VideoManager.this, sortPreferenceMedia.getSortBy(SortType.TITLE), sortPreferenceMedia.getSortOrder(), getHideWatched(context));
+ 			}
+ 		});
+ 	}
+@@ -75,7 +75,7 @@ public class VideoManager extends AbstractManager implements IVideoManager, ISor
+ 	 */
+ 	public ArrayList<Movie> getMovies(final Context context) {
+ 		try {
+-			return video(context).getMovies(VideoManager.this, getSortBy(SortType.TITLE), getSortOrder(), getHideWatched(context));
++			return video(context).getMovies(VideoManager.this, sortPreferenceMedia.getSortBy(SortType.TITLE), sortPreferenceMedia.getSortOrder(), getHideWatched(context));
+ 		} catch (WifiStateException e) {
+ 			e.printStackTrace();
+ 		}
+@@ -88,7 +88,7 @@ public class VideoManager extends AbstractManager implements IVideoManager, ISor
+ 	 */
+ 	public ArrayList<Movie> getMovies(final Context context, int offset) {
+ 		try {
+-			return video(context).getMovies(VideoManager.this, getSortBy(SortType.TITLE), getSortOrder(), offset, getHideWatched(context));
++			return video(context).getMovies(VideoManager.this, sortPreferenceMedia.getSortBy(SortType.TITLE), sortPreferenceMedia.getSortOrder(), offset, getHideWatched(context));
+ 		} catch (WifiStateException e) {
+ 			e.printStackTrace();
+ 		}
+@@ -104,7 +104,7 @@ public class VideoManager extends AbstractManager implements IVideoManager, ISor
+ 		mHandler.post(new Command<ArrayList<Movie>>(response, this) {
+ 			@Override
+ 			public void doRun() throws Exception { 
+-				response.value = video(context).getMovies(VideoManager.this, actor, getSortBy(SortType.TITLE), getSortOrder(), getHideWatched(context));
++				response.value = video(context).getMovies(VideoManager.this, actor, sortPreferenceMedia.getSortBy(SortType.TITLE), sortPreferenceMedia.getSortOrder(), getHideWatched(context));
+ 			}
+ 		});
+ 	}
+@@ -118,7 +118,7 @@ public class VideoManager extends AbstractManager implements IVideoManager, ISor
+ 		mHandler.post(new Command<ArrayList<Movie>>(response, this) {
+ 			@Override
+ 			public void doRun() throws Exception { 
+-				response.value = video(context).getMovies(VideoManager.this, genre, getSortBy(SortType.TITLE), getSortOrder(), getHideWatched(context));
++				response.value = video(context).getMovies(VideoManager.this, genre, sortPreferenceMedia.getSortBy(SortType.TITLE), sortPreferenceMedia.getSortOrder(), getHideWatched(context));
+ 			}
+ 		});
+ 	}
+diff --git a/src/org/xbmc/android/remote/presentation/controller/AlbumListController.java b/src/org/xbmc/android/remote/presentation/controller/AlbumListController.java
+index fadad37..70f4dc8 100644
+--- a/src/org/xbmc/android/remote/presentation/controller/AlbumListController.java
++++ b/src/org/xbmc/android/remote/presentation/controller/AlbumListController.java
+@@ -24,8 +24,8 @@ package org.xbmc.android.remote.presentation.controller;
+ import java.util.ArrayList;
+ 
+ import org.xbmc.android.remote.R;
+-import org.xbmc.android.remote.business.AbstractManager;
+ import org.xbmc.android.remote.business.ManagerFactory;
++import org.xbmc.android.remote.business.SortPreferenceMedia;
+ import org.xbmc.android.remote.presentation.activity.DialogFactory;
+ import org.xbmc.android.remote.presentation.activity.ListActivity;
+ import org.xbmc.android.remote.presentation.widget.ThreeLabelsItemView;
+@@ -126,7 +126,7 @@ public class AlbumListController extends ListController implements IController {
+ 		mMusicManager = ManagerFactory.getMusicManager(this);
+ 		mControlManager = ManagerFactory.getControlManager(this);
+ 		
+-		((ISortableManager)mMusicManager).setSortKey(AbstractManager.PREF_SORT_KEY_ALBUM);
++		((ISortableManager)mMusicManager).setSortKey(SortPreferenceMedia.PREF_SORT_KEY_ALBUM);
+ 		((ISortableManager)mMusicManager).setPreferences(activity.getPreferences(Context.MODE_PRIVATE));
+ 		
+ 		final String sdError = ImportUtilities.assertSdCard();
+@@ -327,43 +327,43 @@ public class AlbumListController extends ListController implements IController {
+ 			break;
+ 		case MENU_SORT_BY_ALBUM_ASC:
+ 			ed = mActivity.getPreferences(Context.MODE_PRIVATE).edit();
+-			ed.putInt(AbstractManager.PREF_SORT_BY_PREFIX + AbstractManager.PREF_SORT_KEY_ALBUM, SortType.ALBUM);
+-			ed.putString(AbstractManager.PREF_SORT_ORDER_PREFIX + AbstractManager.PREF_SORT_KEY_ALBUM, SortType.ORDER_ASC);
++			ed.putInt(SortPreferenceMedia.PREF_SORT_BY_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_ALBUM, SortType.ALBUM);
++			ed.putString(SortPreferenceMedia.PREF_SORT_ORDER_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_ALBUM, SortType.ORDER_ASC);
+ 			ed.commit();
+ 			fetch();
+ 			break;
+ 		case MENU_SORT_BY_ALBUM_DESC:
+ 			ed = mActivity.getPreferences(Context.MODE_PRIVATE).edit();
+-			ed.putInt(AbstractManager.PREF_SORT_BY_PREFIX + AbstractManager.PREF_SORT_KEY_ALBUM, SortType.ALBUM);
+-			ed.putString(AbstractManager.PREF_SORT_ORDER_PREFIX + AbstractManager.PREF_SORT_KEY_ALBUM, SortType.ORDER_DESC);
++			ed.putInt(SortPreferenceMedia.PREF_SORT_BY_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_ALBUM, SortType.ALBUM);
++			ed.putString(SortPreferenceMedia.PREF_SORT_ORDER_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_ALBUM, SortType.ORDER_DESC);
+ 			ed.commit();
+ 			fetch();
+ 			break;
+ 		case MENU_SORT_BY_ARTIST_ASC:
+ 			ed = mActivity.getPreferences(Context.MODE_PRIVATE).edit();
+-			ed.putInt(AbstractManager.PREF_SORT_BY_PREFIX + AbstractManager.PREF_SORT_KEY_ALBUM, SortType.ARTIST);
+-			ed.putString(AbstractManager.PREF_SORT_ORDER_PREFIX + AbstractManager.PREF_SORT_KEY_ALBUM, SortType.ORDER_ASC);
++			ed.putInt(SortPreferenceMedia.PREF_SORT_BY_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_ALBUM, SortType.ARTIST);
++			ed.putString(SortPreferenceMedia.PREF_SORT_ORDER_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_ALBUM, SortType.ORDER_ASC);
+ 			ed.commit();
+ 			fetch();
+ 			break;
+ 		case MENU_SORT_BY_ARTIST_DESC:
+ 			ed = mActivity.getPreferences(Context.MODE_PRIVATE).edit();
+-			ed.putInt(AbstractManager.PREF_SORT_BY_PREFIX + AbstractManager.PREF_SORT_KEY_ALBUM, SortType.ARTIST);
+-			ed.putString(AbstractManager.PREF_SORT_ORDER_PREFIX + AbstractManager.PREF_SORT_KEY_ALBUM, SortType.ORDER_DESC);
++			ed.putInt(SortPreferenceMedia.PREF_SORT_BY_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_ALBUM, SortType.ARTIST);
++			ed.putString(SortPreferenceMedia.PREF_SORT_ORDER_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_ALBUM, SortType.ORDER_DESC);
+ 			ed.commit();
+ 			fetch();
+ 			break;
+ 		case MENU_SORT_BY_YEAR_ASC:
+ 			ed = mActivity.getPreferences(Context.MODE_PRIVATE).edit();
+-			ed.putInt(AbstractManager.PREF_SORT_BY_PREFIX + AbstractManager.PREF_SORT_KEY_ALBUM, SortType.YEAR);
+-			ed.putString(AbstractManager.PREF_SORT_ORDER_PREFIX + AbstractManager.PREF_SORT_KEY_ALBUM, SortType.ORDER_ASC);
++			ed.putInt(SortPreferenceMedia.PREF_SORT_BY_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_ALBUM, SortType.YEAR);
++			ed.putString(SortPreferenceMedia.PREF_SORT_ORDER_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_ALBUM, SortType.ORDER_ASC);
+ 			ed.commit();
+ 			fetch();
+ 			break;
+ 		case MENU_SORT_BY_YEAR_DESC:
+ 			ed = mActivity.getPreferences(Context.MODE_PRIVATE).edit();
+-			ed.putInt(AbstractManager.PREF_SORT_BY_PREFIX + AbstractManager.PREF_SORT_KEY_ALBUM, SortType.YEAR);
+-			ed.putString(AbstractManager.PREF_SORT_ORDER_PREFIX + AbstractManager.PREF_SORT_KEY_ALBUM, SortType.ORDER_DESC);
++			ed.putInt(SortPreferenceMedia.PREF_SORT_BY_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_ALBUM, SortType.YEAR);
++			ed.putString(SortPreferenceMedia.PREF_SORT_ORDER_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_ALBUM, SortType.ORDER_DESC);
+ 			ed.commit();
+ 			fetch();
+ 			break;
+diff --git a/src/org/xbmc/android/remote/presentation/controller/EpisodeListController.java b/src/org/xbmc/android/remote/presentation/controller/EpisodeListController.java
+index 4728746..b512e08 100644
+--- a/src/org/xbmc/android/remote/presentation/controller/EpisodeListController.java
++++ b/src/org/xbmc/android/remote/presentation/controller/EpisodeListController.java
+@@ -24,8 +24,8 @@ package org.xbmc.android.remote.presentation.controller;
+ import java.util.ArrayList;
+ 
+ import org.xbmc.android.remote.R;
+-import org.xbmc.android.remote.business.AbstractManager;
+ import org.xbmc.android.remote.business.ManagerFactory;
++import org.xbmc.android.remote.business.SortPreferenceMedia;
+ import org.xbmc.android.remote.presentation.activity.EpisodeDetailsActivity;
+ import org.xbmc.android.remote.presentation.activity.NowPlayingActivity;
+ import org.xbmc.android.remote.presentation.widget.FiveLabelsItemView;
+@@ -134,7 +134,7 @@ public class EpisodeListController extends ListController implements IController
+ 	
+ 	private void fetch() {		
+ 		// tv show and episode both are using the same manager so set the sort key here
+-		((ISortableManager)mTvManager).setSortKey(AbstractManager.PREF_SORT_KEY_EPISODE);
++		((ISortableManager)mTvManager).setSortKey(SortPreferenceMedia.PREF_SORT_KEY_EPISODE);
+ 		((ISortableManager)mTvManager).setPreferences(mActivity.getPreferences(Context.MODE_PRIVATE));
+ 		
+ 		final String title = mSeason != null ? mSeason.getName() + " - " : "" + "Episodes";
+@@ -267,43 +267,43 @@ public class EpisodeListController extends ListController implements IController
+ 			break;
+ 		case MENU_SORT_BY_EPISODE_ASC:
+ 			ed = mActivity.getPreferences(Context.MODE_PRIVATE).edit();
+-			ed.putInt(AbstractManager.PREF_SORT_BY_PREFIX + AbstractManager.PREF_SORT_KEY_EPISODE, SortType.EPISODE_NUM);
+-			ed.putString(AbstractManager.PREF_SORT_ORDER_PREFIX + AbstractManager.PREF_SORT_KEY_EPISODE, SortType.ORDER_ASC);
++			ed.putInt(SortPreferenceMedia.PREF_SORT_BY_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_EPISODE, SortType.EPISODE_NUM);
++			ed.putString(SortPreferenceMedia.PREF_SORT_ORDER_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_EPISODE, SortType.ORDER_ASC);
+ 			ed.commit();
+ 			fetch();
+ 			break;
+ 		case MENU_SORT_BY_EPISODE_DESC:
+ 			ed = mActivity.getPreferences(Context.MODE_PRIVATE).edit();
+-			ed.putInt(AbstractManager.PREF_SORT_BY_PREFIX + AbstractManager.PREF_SORT_KEY_EPISODE, SortType.EPISODE_NUM);
+-			ed.putString(AbstractManager.PREF_SORT_ORDER_PREFIX + AbstractManager.PREF_SORT_KEY_EPISODE, SortType.ORDER_DESC);
++			ed.putInt(SortPreferenceMedia.PREF_SORT_BY_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_EPISODE, SortType.EPISODE_NUM);
++			ed.putString(SortPreferenceMedia.PREF_SORT_ORDER_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_EPISODE, SortType.ORDER_DESC);
+ 			ed.commit();
+ 			fetch();
+ 			break;
+ 		case MENU_SORT_BY_TITLE_ASC:
+ 			ed = mActivity.getPreferences(Context.MODE_PRIVATE).edit();
+-			ed.putInt(AbstractManager.PREF_SORT_BY_PREFIX + AbstractManager.PREF_SORT_KEY_EPISODE, SortType.EPISODE_TITLE);
+-			ed.putString(AbstractManager.PREF_SORT_ORDER_PREFIX + AbstractManager.PREF_SORT_KEY_EPISODE, SortType.ORDER_ASC);
++			ed.putInt(SortPreferenceMedia.PREF_SORT_BY_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_EPISODE, SortType.EPISODE_TITLE);
++			ed.putString(SortPreferenceMedia.PREF_SORT_ORDER_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_EPISODE, SortType.ORDER_ASC);
+ 			ed.commit();
+ 			fetch();
+ 			break;
+ 		case MENU_SORT_BY_TITLE_DESC:
+ 			ed = mActivity.getPreferences(Context.MODE_PRIVATE).edit();
+-			ed.putInt(AbstractManager.PREF_SORT_BY_PREFIX + AbstractManager.PREF_SORT_KEY_EPISODE, SortType.EPISODE_TITLE);
+-			ed.putString(AbstractManager.PREF_SORT_ORDER_PREFIX + AbstractManager.PREF_SORT_KEY_EPISODE, SortType.ORDER_DESC);
++			ed.putInt(SortPreferenceMedia.PREF_SORT_BY_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_EPISODE, SortType.EPISODE_TITLE);
++			ed.putString(SortPreferenceMedia.PREF_SORT_ORDER_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_EPISODE, SortType.ORDER_DESC);
+ 			ed.commit();
+ 			fetch();
+ 			break;
+ 		case MENU_SORT_BY_RATING_ASC:
+ 			ed = mActivity.getPreferences(Context.MODE_PRIVATE).edit();
+-			ed.putInt(AbstractManager.PREF_SORT_BY_PREFIX + AbstractManager.PREF_SORT_KEY_EPISODE, SortType.EPISODE_RATING);
+-			ed.putString(AbstractManager.PREF_SORT_ORDER_PREFIX + AbstractManager.PREF_SORT_KEY_EPISODE, SortType.ORDER_ASC);
++			ed.putInt(SortPreferenceMedia.PREF_SORT_BY_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_EPISODE, SortType.EPISODE_RATING);
++			ed.putString(SortPreferenceMedia.PREF_SORT_ORDER_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_EPISODE, SortType.ORDER_ASC);
+ 			ed.commit();
+ 			fetch();
+ 			break;
+ 		case MENU_SORT_BY_RATING_DESC:
+ 			ed = mActivity.getPreferences(Context.MODE_PRIVATE).edit();
+-			ed.putInt(AbstractManager.PREF_SORT_BY_PREFIX + AbstractManager.PREF_SORT_KEY_EPISODE, SortType.EPISODE_RATING);
+-			ed.putString(AbstractManager.PREF_SORT_ORDER_PREFIX + AbstractManager.PREF_SORT_KEY_SHOW, SortType.ORDER_DESC);
++			ed.putInt(SortPreferenceMedia.PREF_SORT_BY_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_EPISODE, SortType.EPISODE_RATING);
++			ed.putString(SortPreferenceMedia.PREF_SORT_ORDER_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_SHOW, SortType.ORDER_DESC);
+ 			ed.commit();
+ 			fetch();
+ 			break;
+diff --git a/src/org/xbmc/android/remote/presentation/controller/MovieListController.java b/src/org/xbmc/android/remote/presentation/controller/MovieListController.java
+index 7bdfbf7..420da51 100644
+--- a/src/org/xbmc/android/remote/presentation/controller/MovieListController.java
++++ b/src/org/xbmc/android/remote/presentation/controller/MovieListController.java
+@@ -24,8 +24,8 @@ package org.xbmc.android.remote.presentation.controller;
+ import java.util.ArrayList;
+ 
+ import org.xbmc.android.remote.R;
+-import org.xbmc.android.remote.business.AbstractManager;
+ import org.xbmc.android.remote.business.ManagerFactory;
++import org.xbmc.android.remote.business.SortPreferenceMedia;
+ import org.xbmc.android.remote.presentation.activity.MovieDetailsActivity;
+ import org.xbmc.android.remote.presentation.activity.NowPlayingActivity;
+ import org.xbmc.android.remote.presentation.widget.FiveLabelsItemView;
+@@ -100,7 +100,7 @@ public class MovieListController extends ListController implements IController {
+ 		mVideoManager = ManagerFactory.getVideoManager(this);
+ 		mControlManager = ManagerFactory.getControlManager(this);
+ 		
+-		((ISortableManager)mVideoManager).setSortKey(AbstractManager.PREF_SORT_KEY_MOVIE);
++		((ISortableManager)mVideoManager).setSortKey(SortPreferenceMedia.PREF_SORT_KEY_MOVIE);
+ 		((ISortableManager)mVideoManager).setPreferences(activity.getPreferences(Context.MODE_PRIVATE));
+ 		
+ 		final String sdError = ImportUtilities.assertSdCard();
+@@ -273,57 +273,57 @@ public class MovieListController extends ListController implements IController {
+ 			break;
+ 		case MENU_SORT_BY_TITLE_ASC:
+ 			ed = mActivity.getPreferences(Context.MODE_PRIVATE).edit();
+-			ed.putInt(AbstractManager.PREF_SORT_BY_PREFIX + AbstractManager.PREF_SORT_KEY_MOVIE, SortType.TITLE);
+-			ed.putString(AbstractManager.PREF_SORT_ORDER_PREFIX + AbstractManager.PREF_SORT_KEY_MOVIE, SortType.ORDER_ASC);
++			ed.putInt(SortPreferenceMedia.PREF_SORT_BY_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_MOVIE, SortType.TITLE);
++			ed.putString(SortPreferenceMedia.PREF_SORT_ORDER_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_MOVIE, SortType.ORDER_ASC);
+ 			ed.commit();
+ 			fetch();
+ 			break;
+ 		case MENU_SORT_BY_TITLE_DESC:
+ 			ed = mActivity.getPreferences(Context.MODE_PRIVATE).edit();
+-			ed.putInt(AbstractManager.PREF_SORT_BY_PREFIX + AbstractManager.PREF_SORT_KEY_MOVIE, SortType.TITLE);
+-			ed.putString(AbstractManager.PREF_SORT_ORDER_PREFIX + AbstractManager.PREF_SORT_KEY_MOVIE, SortType.ORDER_DESC);
++			ed.putInt(SortPreferenceMedia.PREF_SORT_BY_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_MOVIE, SortType.TITLE);
++			ed.putString(SortPreferenceMedia.PREF_SORT_ORDER_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_MOVIE, SortType.ORDER_DESC);
+ 			ed.commit();
+ 			fetch();
+ 			break;
+ 		case MENU_SORT_BY_YEAR_ASC:
+ 			ed = mActivity.getPreferences(Context.MODE_PRIVATE).edit();
+-			ed.putInt(AbstractManager.PREF_SORT_BY_PREFIX + AbstractManager.PREF_SORT_KEY_MOVIE, SortType.YEAR);
+-			ed.putString(AbstractManager.PREF_SORT_ORDER_PREFIX + AbstractManager.PREF_SORT_KEY_MOVIE, SortType.ORDER_ASC);
++			ed.putInt(SortPreferenceMedia.PREF_SORT_BY_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_MOVIE, SortType.YEAR);
++			ed.putString(SortPreferenceMedia.PREF_SORT_ORDER_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_MOVIE, SortType.ORDER_ASC);
+ 			ed.commit();
+ 			fetch();
+ 			break;
+ 		case MENU_SORT_BY_YEAR_DESC:
+ 			ed = mActivity.getPreferences(Context.MODE_PRIVATE).edit();
+-			ed.putInt(AbstractManager.PREF_SORT_BY_PREFIX + AbstractManager.PREF_SORT_KEY_MOVIE, SortType.YEAR);
+-			ed.putString(AbstractManager.PREF_SORT_ORDER_PREFIX + AbstractManager.PREF_SORT_KEY_MOVIE, SortType.ORDER_DESC);
++			ed.putInt(SortPreferenceMedia.PREF_SORT_BY_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_MOVIE, SortType.YEAR);
++			ed.putString(SortPreferenceMedia.PREF_SORT_ORDER_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_MOVIE, SortType.ORDER_DESC);
+ 			ed.commit();
+ 			fetch();
+ 			break;
+ 		case MENU_SORT_BY_RATING_ASC:
+ 			ed = mActivity.getPreferences(Context.MODE_PRIVATE).edit();
+-			ed.putInt(AbstractManager.PREF_SORT_BY_PREFIX + AbstractManager.PREF_SORT_KEY_MOVIE, SortType.RATING);
+-			ed.putString(AbstractManager.PREF_SORT_ORDER_PREFIX + AbstractManager.PREF_SORT_KEY_MOVIE, SortType.ORDER_ASC);
++			ed.putInt(SortPreferenceMedia.PREF_SORT_BY_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_MOVIE, SortType.RATING);
++			ed.putString(SortPreferenceMedia.PREF_SORT_ORDER_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_MOVIE, SortType.ORDER_ASC);
+ 			ed.commit();
+ 			fetch();
+ 			break;
+ 		case MENU_SORT_BY_RATING_DESC:
+ 			ed = mActivity.getPreferences(Context.MODE_PRIVATE).edit();
+-			ed.putInt(AbstractManager.PREF_SORT_BY_PREFIX + AbstractManager.PREF_SORT_KEY_MOVIE, SortType.RATING);
+-			ed.putString(AbstractManager.PREF_SORT_ORDER_PREFIX + AbstractManager.PREF_SORT_KEY_MOVIE, SortType.ORDER_DESC);
++			ed.putInt(SortPreferenceMedia.PREF_SORT_BY_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_MOVIE, SortType.RATING);
++			ed.putString(SortPreferenceMedia.PREF_SORT_ORDER_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_MOVIE, SortType.ORDER_DESC);
+ 			ed.commit();
+ 			fetch();
+ 			break;
+ 		case MENU_SORT_BY_DATE_ADDED_ASC:
+ 			ed = mActivity.getPreferences(Context.MODE_PRIVATE).edit();
+-			ed.putInt(AbstractManager.PREF_SORT_BY_PREFIX + AbstractManager.PREF_SORT_KEY_MOVIE, SortType.DATE_ADDED);
+-			ed.putString(AbstractManager.PREF_SORT_ORDER_PREFIX + AbstractManager.PREF_SORT_KEY_MOVIE, SortType.ORDER_ASC);
++			ed.putInt(SortPreferenceMedia.PREF_SORT_BY_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_MOVIE, SortType.DATE_ADDED);
++			ed.putString(SortPreferenceMedia.PREF_SORT_ORDER_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_MOVIE, SortType.ORDER_ASC);
+ 			ed.commit();
+ 			fetch();
+ 			break;
+ 		case MENU_SORT_BY_DATE_ADDED_DESC:
+ 			ed = mActivity.getPreferences(Context.MODE_PRIVATE).edit();
+-			ed.putInt(AbstractManager.PREF_SORT_BY_PREFIX + AbstractManager.PREF_SORT_KEY_MOVIE, SortType.DATE_ADDED);
+-			ed.putString(AbstractManager.PREF_SORT_ORDER_PREFIX + AbstractManager.PREF_SORT_KEY_MOVIE, SortType.ORDER_DESC);
++			ed.putInt(SortPreferenceMedia.PREF_SORT_BY_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_MOVIE, SortType.DATE_ADDED);
++			ed.putString(SortPreferenceMedia.PREF_SORT_ORDER_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_MOVIE, SortType.ORDER_DESC);
+ 			ed.commit();
+ 			fetch();
+ 			break;
+diff --git a/src/org/xbmc/android/remote/presentation/controller/SongListController.java b/src/org/xbmc/android/remote/presentation/controller/SongListController.java
+index 9d5b4d5..ab89735 100644
+--- a/src/org/xbmc/android/remote/presentation/controller/SongListController.java
++++ b/src/org/xbmc/android/remote/presentation/controller/SongListController.java
+@@ -24,8 +24,8 @@ package org.xbmc.android.remote.presentation.controller;
+ import java.util.ArrayList;
+ 
+ import org.xbmc.android.remote.R;
+-import org.xbmc.android.remote.business.AbstractManager;
+ import org.xbmc.android.remote.business.ManagerFactory;
++import org.xbmc.android.remote.business.SortPreferenceMedia;
+ import org.xbmc.android.remote.presentation.widget.ThreeLabelsItemView;
+ import org.xbmc.android.util.ImportUtilities;
+ import org.xbmc.api.business.DataResponse;
+@@ -95,7 +95,7 @@ public class SongListController extends ListController implements IController {
+ 		
+ 		mMusicManager = ManagerFactory.getMusicManager(this);
+ 		
+-		((ISortableManager)mMusicManager).setSortKey(AbstractManager.PREF_SORT_KEY_SONG);
++		((ISortableManager)mMusicManager).setSortKey(SortPreferenceMedia.PREF_SORT_KEY_SONG);
+ 		((ISortableManager)mMusicManager).setPreferences(activity.getPreferences(Context.MODE_PRIVATE));
+ 		
+ 		final String sdError = ImportUtilities.assertSdCard();
+@@ -276,57 +276,57 @@ public class SongListController extends ListController implements IController {
+ 			break;
+ 		case MENU_SORT_BY_ALBUM_ASC:
+ 			ed = mActivity.getPreferences(Context.MODE_PRIVATE).edit();
+-			ed.putInt(AbstractManager.PREF_SORT_BY_PREFIX + AbstractManager.PREF_SORT_KEY_SONG, SortType.ALBUM);
+-			ed.putString(AbstractManager.PREF_SORT_ORDER_PREFIX + AbstractManager.PREF_SORT_KEY_SONG, SortType.ORDER_ASC);
++			ed.putInt(SortPreferenceMedia.PREF_SORT_BY_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_SONG, SortType.ALBUM);
++			ed.putString(SortPreferenceMedia.PREF_SORT_ORDER_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_SONG, SortType.ORDER_ASC);
+ 			ed.commit();
+ 			fetch();
+ 			break;
+ 		case MENU_SORT_BY_ALBUM_DESC:
+ 			ed = mActivity.getPreferences(Context.MODE_PRIVATE).edit();
+-			ed.putInt(AbstractManager.PREF_SORT_BY_PREFIX + AbstractManager.PREF_SORT_KEY_SONG, SortType.ALBUM);
+-			ed.putString(AbstractManager.PREF_SORT_ORDER_PREFIX + AbstractManager.PREF_SORT_KEY_SONG, SortType.ORDER_DESC);
++			ed.putInt(SortPreferenceMedia.PREF_SORT_BY_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_SONG, SortType.ALBUM);
++			ed.putString(SortPreferenceMedia.PREF_SORT_ORDER_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_SONG, SortType.ORDER_DESC);
+ 			ed.commit();
+ 			fetch();
+ 			break;
+ 		case MENU_SORT_BY_ARTIST_ASC:
+ 			ed = mActivity.getPreferences(Context.MODE_PRIVATE).edit();
+-			ed.putInt(AbstractManager.PREF_SORT_BY_PREFIX + AbstractManager.PREF_SORT_KEY_SONG, SortType.ARTIST);
+-			ed.putString(AbstractManager.PREF_SORT_ORDER_PREFIX + AbstractManager.PREF_SORT_KEY_SONG, SortType.ORDER_ASC);
++			ed.putInt(SortPreferenceMedia.PREF_SORT_BY_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_SONG, SortType.ARTIST);
++			ed.putString(SortPreferenceMedia.PREF_SORT_ORDER_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_SONG, SortType.ORDER_ASC);
+ 			ed.commit();
+ 			fetch();
+ 			break;
+ 		case MENU_SORT_BY_ARTIST_DESC:
+ 			ed = mActivity.getPreferences(Context.MODE_PRIVATE).edit();
+-			ed.putInt(AbstractManager.PREF_SORT_BY_PREFIX + AbstractManager.PREF_SORT_KEY_SONG, SortType.ARTIST);
+-			ed.putString(AbstractManager.PREF_SORT_ORDER_PREFIX + AbstractManager.PREF_SORT_KEY_SONG, SortType.ORDER_DESC);
++			ed.putInt(SortPreferenceMedia.PREF_SORT_BY_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_SONG, SortType.ARTIST);
++			ed.putString(SortPreferenceMedia.PREF_SORT_ORDER_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_SONG, SortType.ORDER_DESC);
+ 			ed.commit();
+ 			fetch();
+ 			break;
+ 		case MENU_SORT_BY_TITLE_ASC:
+ 			ed = mActivity.getPreferences(Context.MODE_PRIVATE).edit();
+-			ed.putInt(AbstractManager.PREF_SORT_BY_PREFIX + AbstractManager.PREF_SORT_KEY_SONG, SortType.TITLE);
+-			ed.putString(AbstractManager.PREF_SORT_ORDER_PREFIX + AbstractManager.PREF_SORT_KEY_SONG, SortType.ORDER_ASC);
++			ed.putInt(SortPreferenceMedia.PREF_SORT_BY_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_SONG, SortType.TITLE);
++			ed.putString(SortPreferenceMedia.PREF_SORT_ORDER_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_SONG, SortType.ORDER_ASC);
+ 			ed.commit();
+ 			fetch();
+ 			break;
+ 		case MENU_SORT_BY_TITLE_DESC:
+ 			ed = mActivity.getPreferences(Context.MODE_PRIVATE).edit();
+-			ed.putInt(AbstractManager.PREF_SORT_BY_PREFIX + AbstractManager.PREF_SORT_KEY_SONG, SortType.TITLE);
+-			ed.putString(AbstractManager.PREF_SORT_ORDER_PREFIX + AbstractManager.PREF_SORT_KEY_SONG, SortType.ORDER_DESC);
++			ed.putInt(SortPreferenceMedia.PREF_SORT_BY_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_SONG, SortType.TITLE);
++			ed.putString(SortPreferenceMedia.PREF_SORT_ORDER_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_SONG, SortType.ORDER_DESC);
+ 			ed.commit();
+ 			fetch();
+ 			break;
+ 		case MENU_SORT_BY_FILENAME_ASC:
+ 			ed = mActivity.getPreferences(Context.MODE_PRIVATE).edit();
+-			ed.putInt(AbstractManager.PREF_SORT_BY_PREFIX + AbstractManager.PREF_SORT_KEY_SONG, SortType.FILENAME);
+-			ed.putString(AbstractManager.PREF_SORT_ORDER_PREFIX + AbstractManager.PREF_SORT_KEY_SONG, SortType.ORDER_ASC);
++			ed.putInt(SortPreferenceMedia.PREF_SORT_BY_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_SONG, SortType.FILENAME);
++			ed.putString(SortPreferenceMedia.PREF_SORT_ORDER_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_SONG, SortType.ORDER_ASC);
+ 			ed.commit();
+ 			fetch();
+ 			break;
+ 		case MENU_SORT_BY_FILENAME_DESC:
+ 			ed = mActivity.getPreferences(Context.MODE_PRIVATE).edit();
+-			ed.putInt(AbstractManager.PREF_SORT_BY_PREFIX + AbstractManager.PREF_SORT_KEY_SONG, SortType.FILENAME);
+-			ed.putString(AbstractManager.PREF_SORT_ORDER_PREFIX + AbstractManager.PREF_SORT_KEY_SONG, SortType.ORDER_DESC);
++			ed.putInt(SortPreferenceMedia.PREF_SORT_BY_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_SONG, SortType.FILENAME);
++			ed.putString(SortPreferenceMedia.PREF_SORT_ORDER_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_SONG, SortType.ORDER_DESC);
+ 			ed.commit();
+ 			fetch();
+ 			break;
+diff --git a/src/org/xbmc/android/remote/presentation/controller/TvShowListController.java b/src/org/xbmc/android/remote/presentation/controller/TvShowListController.java
+index 22d2757..71af809 100644
+--- a/src/org/xbmc/android/remote/presentation/controller/TvShowListController.java
++++ b/src/org/xbmc/android/remote/presentation/controller/TvShowListController.java
+@@ -24,8 +24,8 @@ package org.xbmc.android.remote.presentation.controller;
+ import java.util.ArrayList;
+ 
+ import org.xbmc.android.remote.R;
+-import org.xbmc.android.remote.business.AbstractManager;
+ import org.xbmc.android.remote.business.ManagerFactory;
++import org.xbmc.android.remote.business.SortPreferenceMedia;
+ import org.xbmc.android.remote.presentation.activity.GridActivity;
+ import org.xbmc.android.remote.presentation.activity.ListActivity;
+ import org.xbmc.android.remote.presentation.activity.TvShowDetailsActivity;
+@@ -136,7 +136,7 @@ public class TvShowListController extends ListController implements IController
+ 	
+ 	private void fetch() {
+ 		// tv show and episode both are using the same manager so set the sort key here
+-		((ISortableManager)mTvManager).setSortKey(AbstractManager.PREF_SORT_KEY_SHOW);
++		((ISortableManager)mTvManager).setSortKey(SortPreferenceMedia.PREF_SORT_KEY_SHOW);
+ 		((ISortableManager)mTvManager).setPreferences(mActivity.getPreferences(Context.MODE_PRIVATE));
+ 
+ 		final String title = mActor != null ? mActor.name + " - " : mGenre != null ? mGenre.name + " - " : "" + "TV Shows";
+@@ -256,43 +256,43 @@ public class TvShowListController extends ListController implements IController
+ 			break;
+ 		case MENU_SORT_BY_TITLE_ASC:
+ 			ed = mActivity.getPreferences(Context.MODE_PRIVATE).edit();
+-			ed.putInt(AbstractManager.PREF_SORT_BY_PREFIX + AbstractManager.PREF_SORT_KEY_SHOW, SortType.TITLE);
+-			ed.putString(AbstractManager.PREF_SORT_ORDER_PREFIX + AbstractManager.PREF_SORT_KEY_SHOW, SortType.ORDER_ASC);
++			ed.putInt(SortPreferenceMedia.PREF_SORT_BY_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_SHOW, SortType.TITLE);
++			ed.putString(SortPreferenceMedia.PREF_SORT_ORDER_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_SHOW, SortType.ORDER_ASC);
+ 			ed.commit();
+ 			fetch();
+ 			break;
+ 		case MENU_SORT_BY_TITLE_DESC:
+ 			ed = mActivity.getPreferences(Context.MODE_PRIVATE).edit();
+-			ed.putInt(AbstractManager.PREF_SORT_BY_PREFIX + AbstractManager.PREF_SORT_KEY_SHOW, SortType.TITLE);
+-			ed.putString(AbstractManager.PREF_SORT_ORDER_PREFIX + AbstractManager.PREF_SORT_KEY_SHOW, SortType.ORDER_DESC);
++			ed.putInt(SortPreferenceMedia.PREF_SORT_BY_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_SHOW, SortType.TITLE);
++			ed.putString(SortPreferenceMedia.PREF_SORT_ORDER_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_SHOW, SortType.ORDER_DESC);
+ 			ed.commit();
+ 			fetch();
+ 			break;
+ 		case MENU_SORT_BY_YEAR_ASC:
+ 			ed = mActivity.getPreferences(Context.MODE_PRIVATE).edit();
+-			ed.putInt(AbstractManager.PREF_SORT_BY_PREFIX + AbstractManager.PREF_SORT_KEY_SHOW, SortType.YEAR);
+-			ed.putString(AbstractManager.PREF_SORT_ORDER_PREFIX + AbstractManager.PREF_SORT_KEY_SHOW, SortType.ORDER_ASC);
++			ed.putInt(SortPreferenceMedia.PREF_SORT_BY_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_SHOW, SortType.YEAR);
++			ed.putString(SortPreferenceMedia.PREF_SORT_ORDER_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_SHOW, SortType.ORDER_ASC);
+ 			ed.commit();
+ 			fetch();
+ 			break;
+ 		case MENU_SORT_BY_YEAR_DESC:
+ 			ed = mActivity.getPreferences(Context.MODE_PRIVATE).edit();
+-			ed.putInt(AbstractManager.PREF_SORT_BY_PREFIX + AbstractManager.PREF_SORT_KEY_SHOW, SortType.YEAR);
+-			ed.putString(AbstractManager.PREF_SORT_ORDER_PREFIX + AbstractManager.PREF_SORT_KEY_SHOW, SortType.ORDER_DESC);
++			ed.putInt(SortPreferenceMedia.PREF_SORT_BY_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_SHOW, SortType.YEAR);
++			ed.putString(SortPreferenceMedia.PREF_SORT_ORDER_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_SHOW, SortType.ORDER_DESC);
+ 			ed.commit();
+ 			fetch();
+ 			break;
+ 		case MENU_SORT_BY_RATING_ASC:
+ 			ed = mActivity.getPreferences(Context.MODE_PRIVATE).edit();
+-			ed.putInt(AbstractManager.PREF_SORT_BY_PREFIX + AbstractManager.PREF_SORT_KEY_SHOW, SortType.RATING);
+-			ed.putString(AbstractManager.PREF_SORT_ORDER_PREFIX + AbstractManager.PREF_SORT_KEY_SHOW, SortType.ORDER_ASC);
++			ed.putInt(SortPreferenceMedia.PREF_SORT_BY_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_SHOW, SortType.RATING);
++			ed.putString(SortPreferenceMedia.PREF_SORT_ORDER_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_SHOW, SortType.ORDER_ASC);
+ 			ed.commit();
+ 			fetch();
+ 			break;
+ 		case MENU_SORT_BY_RATING_DESC:
+ 			ed = mActivity.getPreferences(Context.MODE_PRIVATE).edit();
+-			ed.putInt(AbstractManager.PREF_SORT_BY_PREFIX + AbstractManager.PREF_SORT_KEY_SHOW, SortType.RATING);
+-			ed.putString(AbstractManager.PREF_SORT_ORDER_PREFIX + AbstractManager.PREF_SORT_KEY_SHOW, SortType.ORDER_DESC);
++			ed.putInt(SortPreferenceMedia.PREF_SORT_BY_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_SHOW, SortType.RATING);
++			ed.putString(SortPreferenceMedia.PREF_SORT_ORDER_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_SHOW, SortType.ORDER_DESC);
+ 			ed.commit();
+ 			fetch();
+ 			break;
+-- 
+1.9.3 (Apple Git-50)
+

--- a/patches/0003-Removed-Sort-Methods-From-AbstractManager.patch
+++ b/patches/0003-Removed-Sort-Methods-From-AbstractManager.patch
@@ -1,0 +1,33 @@
+From 9e86e636cf41432feb3b61a15821b4c7f4f2bbea Mon Sep 17 00:00:00 2001
+From: Corey Lee <lee.j.corey@gmail.com>
+Date: Wed, 26 Nov 2014 23:42:11 -0500
+Subject: [PATCH 3/3] Removed Sort Methods From AbstractManager
+
+- Removed Unnecessary method getSortOrder from AbstractManager
+---
+ src/org/xbmc/android/remote/business/AbstractManager.java | 9 ---------
+ 1 file changed, 9 deletions(-)
+
+diff --git a/src/org/xbmc/android/remote/business/AbstractManager.java b/src/org/xbmc/android/remote/business/AbstractManager.java
+index a4da556..ee036c5 100644
+--- a/src/org/xbmc/android/remote/business/AbstractManager.java
++++ b/src/org/xbmc/android/remote/business/AbstractManager.java
+@@ -317,15 +317,6 @@ public abstract class AbstractManager implements INotifiableManager {
+ 	{
+ 		mHandler.post(runnable);
+ 	}
+-
+-	/**
+-	 * Returns currently saved "sort by" value. If the preference was not set yet, or
+-	 * if the current sort key is not set, return "ASC".
+-	 * @return Sort order
+-	 */
+-	protected String getSortOrder() {
+-        return sortPreferenceMedia.getSortOrder();
+-    }
+ 	
+ 	protected boolean getHideWatched(Context context) {
+ 		return context.getSharedPreferences("global", Context.MODE_PRIVATE).getBoolean("HideWatched", false);
+-- 
+1.9.3 (Apple Git-50)
+

--- a/src/org/xbmc/android/remote/business/AbstractManager.java
+++ b/src/org/xbmc/android/remote/business/AbstractManager.java
@@ -36,12 +36,10 @@ import org.xbmc.api.data.IVideoClient;
 import org.xbmc.api.object.ICoverArt;
 import org.xbmc.api.presentation.INotifiableController;
 import org.xbmc.api.type.CacheType;
-import org.xbmc.api.type.SortType;
 import org.xbmc.api.type.ThumbSize;
 import org.xbmc.httpapi.WifiStateException;
 
 import android.content.Context;
-import android.content.SharedPreferences;
 import android.graphics.Bitmap;
 import android.os.Handler;
 import android.util.Log;
@@ -56,31 +54,14 @@ public abstract class AbstractManager implements INotifiableManager {
 	public static final Boolean DEBUG = false;
 	
 	protected static final String TAG = "AbstractManager";
-	
-	public static final String PREF_SORT_BY_PREFIX = "sort_by_";
-	public static final String PREF_SORT_ORDER_PREFIX = "sort_order_";
-	
-	/* The idea of the sort keys is to remember different sort settings for
-	 * each type. In your controller, make sure you run setSortKey() in the
-	 * onCreate() method.
-	 */
-	public static final int PREF_SORT_KEY_ALBUM = 1;
-	public static final int PREF_SORT_KEY_ARTIST = 2;
-	public static final int PREF_SORT_KEY_SONG = 3;
-	public static final int PREF_SORT_KEY_GENRE = 4;
-	public static final int PREF_SORT_KEY_FILEMODE = 5;
-	public static final int PREF_SORT_KEY_SHOW = 6;
-	public static final int PREF_SORT_KEY_MOVIE = 7;
-	public static final int PREF_SORT_KEY_EPISODE = 8;
-	
-	protected INotifiableController mController = null;
+
+    protected final SortPreferenceMedia sortPreferenceMedia = new SortPreferenceMedia();
+
+    protected INotifiableController mController = null;
 	
 	protected Handler mHandler;
-	
-	protected SharedPreferences mPref;
-	protected int mCurrentSortKey;
-	
-	protected List<Runnable> failedRequests = new ArrayList<Runnable>();
+
+    protected List<Runnable> failedRequests = new ArrayList<Runnable>();
 	/**
 	 * Sets the handler used in the looping thread
 	 * @param handler
@@ -331,53 +312,20 @@ public abstract class AbstractManager implements INotifiableManager {
 			}
 		});
 	}
-	
-	/**
-	 * Sets the static reference to the preferences object. Used to obtain
-	 * current sort values.
-	 * @param pref
-	 */
-	public void setPreferences(SharedPreferences pref) {
-		mPref = pref;
-	}
 
-	/**
-	 * Sets which kind of view is currently active.
-	 * @param sortKey
-	 */
-	public void setSortKey(int sortKey) {
-		mCurrentSortKey = sortKey;
-	}
-	
-	public void post(Runnable runnable)
+    public void post(Runnable runnable)
 	{
 		mHandler.post(runnable);
 	}
-	
-	/**
-	 * Returns currently saved "sort by" value. If the preference was not set yet, or
-	 * if the current sort key is not set, return default value.
-	 * @param type Default value
-	 * @return Sort by field
-	 */
-	protected int getSortBy(int type) {
-		if (mPref != null) {
-			return mPref.getInt(PREF_SORT_BY_PREFIX + mCurrentSortKey, type);
-		}
-		return type;
-	}
-	
+
 	/**
 	 * Returns currently saved "sort by" value. If the preference was not set yet, or
 	 * if the current sort key is not set, return "ASC".
 	 * @return Sort order
 	 */
 	protected String getSortOrder() {
-		if (mPref != null) {
-			return mPref.getString(PREF_SORT_ORDER_PREFIX + mCurrentSortKey, SortType.ORDER_ASC);
-		}
-		return SortType.ORDER_ASC;
-	}
+        return sortPreferenceMedia.getSortOrder();
+    }
 	
 	protected boolean getHideWatched(Context context) {
 		return context.getSharedPreferences("global", Context.MODE_PRIVATE).getBoolean("HideWatched", false);

--- a/src/org/xbmc/android/remote/business/AbstractManager.java
+++ b/src/org/xbmc/android/remote/business/AbstractManager.java
@@ -317,15 +317,6 @@ public abstract class AbstractManager implements INotifiableManager {
 	{
 		mHandler.post(runnable);
 	}
-
-	/**
-	 * Returns currently saved "sort by" value. If the preference was not set yet, or
-	 * if the current sort key is not set, return "ASC".
-	 * @return Sort order
-	 */
-	protected String getSortOrder() {
-        return sortPreferenceMedia.getSortOrder();
-    }
 	
 	protected boolean getHideWatched(Context context) {
 		return context.getSharedPreferences("global", Context.MODE_PRIVATE).getBoolean("HideWatched", false);

--- a/src/org/xbmc/android/remote/business/MusicManager.java
+++ b/src/org/xbmc/android/remote/business/MusicManager.java
@@ -46,7 +46,7 @@ import android.content.Context;
  * 
  * @author Team XBMC
  */
-public class MusicManager extends AbstractManager implements IMusicManager, ISortableManager, INotifiableManager {
+public class MusicManager extends AbstractManager implements IMusicManager, INotifiableManager {
 	
 	/**
 	 * Gets all albums from database
@@ -71,7 +71,7 @@ public class MusicManager extends AbstractManager implements IMusicManager, ISor
 		mHandler.post(new Command<ArrayList<Album>>(response, this) {
 			@Override
 			public void doRun() throws Exception {
-				response.value = music(context).getAlbums(MusicManager.this, getSortBy(SortType.ALBUM), getSortOrder());
+				response.value = music(context).getAlbums(MusicManager.this, sortPreferenceMedia.getSortBy(SortType.ALBUM), sortPreferenceMedia.getSortOrder());
 			}
 		});
 	}
@@ -82,7 +82,7 @@ public class MusicManager extends AbstractManager implements IMusicManager, ISor
 	 */
 	public ArrayList<Album> getAlbums(final Context context) {
 		try { //TODO fix this to throw 
-			return music(context).getAlbums(MusicManager.this, getSortBy(SortType.ALBUM), getSortOrder());
+			return music(context).getAlbums(MusicManager.this, sortPreferenceMedia.getSortBy(SortType.ALBUM), sortPreferenceMedia.getSortOrder());
 		} catch (WifiStateException e) {
 			e.printStackTrace();
 		}
@@ -104,7 +104,7 @@ public class MusicManager extends AbstractManager implements IMusicManager, ISor
 		mHandler.post(new Command<ArrayList<Album>>(response, this){
 			@Override
 			public void doRun() throws Exception {
-				response.value = music(context).getAlbums(MusicManager.this, artist, getSortBy(SortType.ALBUM), getSortOrder());
+				response.value = music(context).getAlbums(MusicManager.this, artist, sortPreferenceMedia.getSortBy(SortType.ALBUM), sortPreferenceMedia.getSortOrder());
 			}
 		});
 	}
@@ -123,7 +123,7 @@ public class MusicManager extends AbstractManager implements IMusicManager, ISor
 //		});
 		mHandler.post(new Command<ArrayList<Album>>(response, this) {
 			public void doRun() throws Exception{ 
-				response.value = music(context).getAlbums(MusicManager.this, genre, getSortBy(SortType.ALBUM), getSortOrder());
+				response.value = music(context).getAlbums(MusicManager.this, genre, sortPreferenceMedia.getSortBy(SortType.ALBUM), sortPreferenceMedia.getSortOrder());
 			}
 		});
 	}
@@ -142,7 +142,7 @@ public class MusicManager extends AbstractManager implements IMusicManager, ISor
 //		});
 		mHandler.post(new Command<ArrayList<Song>>(response, this) {
 			public void doRun() throws Exception{ 
-				response.value = music(context).getSongs(MusicManager.this, album, getSortBy(SortType.TRACK), getSortOrder());
+				response.value = music(context).getSongs(MusicManager.this, album, sortPreferenceMedia.getSortBy(SortType.TRACK), sortPreferenceMedia.getSortOrder());
 			}
 		});
 	}
@@ -161,7 +161,7 @@ public class MusicManager extends AbstractManager implements IMusicManager, ISor
 //		});
 		mHandler.post(new Command<ArrayList<Song>>(response, this) {
 			public void doRun() throws Exception{ 
-				response.value = music(context).getSongs(MusicManager.this, artist, getSortBy(SortType.ARTIST), getSortOrder());
+				response.value = music(context).getSongs(MusicManager.this, artist, sortPreferenceMedia.getSortBy(SortType.ARTIST), sortPreferenceMedia.getSortOrder());
 			}
 		});
 	}
@@ -180,7 +180,7 @@ public class MusicManager extends AbstractManager implements IMusicManager, ISor
 //		});
 		mHandler.post(new Command<ArrayList<Song>>(response, this) {
 			public void doRun() throws Exception{ 
-				response.value = music(context).getSongs(MusicManager.this, genre, getSortBy(SortType.ARTIST), getSortOrder());
+				response.value = music(context).getSongs(MusicManager.this, genre, sortPreferenceMedia.getSortBy(SortType.ARTIST), sortPreferenceMedia.getSortOrder());
 			}
 		});
 	}
@@ -278,7 +278,7 @@ public class MusicManager extends AbstractManager implements IMusicManager, ISor
 				final IMusicClient mc = music(context);
 				final IControlClient cc = control(context);
 				final int numAlreadyQueued = mc.getPlaylistSize(MusicManager.this);
-				response.value = mc.addToPlaylist(MusicManager.this, album, getSortBy(SortType.TRACK), getSortOrder());
+				response.value = mc.addToPlaylist(MusicManager.this, album, sortPreferenceMedia.getSortBy(SortType.TRACK), sortPreferenceMedia.getSortOrder());
 				checkForPlayAfterQueue(mc, cc, numAlreadyQueued);
 			}
 		});
@@ -296,7 +296,7 @@ public class MusicManager extends AbstractManager implements IMusicManager, ISor
 				final IMusicClient mc = music(context);
 				final IControlClient cc = control(context);
 				final int numAlreadyQueued = mc.getPlaylistSize(MusicManager.this);
-				response.value = mc.addToPlaylist(MusicManager.this, genre, getSortBy(SortType.ARTIST), getSortOrder());
+				response.value = mc.addToPlaylist(MusicManager.this, genre, sortPreferenceMedia.getSortBy(SortType.ARTIST), sortPreferenceMedia.getSortOrder());
 				checkForPlayAfterQueue(mc, cc, numAlreadyQueued);
 			}
 		});
@@ -338,14 +338,14 @@ public class MusicManager extends AbstractManager implements IMusicManager, ISor
 				int playPos = -1;
 				if (playlistSize == 0) {  // if playlist is empty, add the whole album
 					int n = 0;
-					for (Song albumSong : mc.getSongs(MusicManager.this, album, getSortBy(PREF_SORT_KEY_ALBUM), getSortOrder())) {
+					for (Song albumSong : mc.getSongs(MusicManager.this, album, sortPreferenceMedia.getSortBy(SortPreferenceMedia.PREF_SORT_KEY_ALBUM), sortPreferenceMedia.getSortOrder())) {
 						if (albumSong.id == song.id) {
 							playPos = n;
 							break;
 						}
 						n++;
 					}
-					mc.addToPlaylist(MusicManager.this, album, getSortBy(PREF_SORT_KEY_ALBUM), getSortOrder());
+					mc.addToPlaylist(MusicManager.this, album, sortPreferenceMedia.getSortBy(SortPreferenceMedia.PREF_SORT_KEY_ALBUM), sortPreferenceMedia.getSortOrder());
 					response.value = true;
 				} else {                          // otherwise, only add the song
 					mc.addToPlaylist(MusicManager.this, song);
@@ -381,7 +381,7 @@ public class MusicManager extends AbstractManager implements IMusicManager, ISor
 				final IMusicClient mc = music(context);
 				final IControlClient cc = control(context);
 				final int numAlreadyQueued = mc.getPlaylistSize(MusicManager.this);
-				response.value = mc.addToPlaylist(MusicManager.this, artist, getSortBy(SortType.ALBUM), getSortOrder());
+				response.value = mc.addToPlaylist(MusicManager.this, artist, sortPreferenceMedia.getSortBy(SortType.ALBUM), sortPreferenceMedia.getSortOrder());
 				checkForPlayAfterQueue(mc, cc, numAlreadyQueued);
 			}
 		});
@@ -400,7 +400,7 @@ public class MusicManager extends AbstractManager implements IMusicManager, ISor
 				final IMusicClient mc = music(context);
 				final IControlClient cc = control(context);
 				final int numAlreadyQueued = mc.getPlaylistSize(MusicManager.this);
-				response.value = mc.addToPlaylist(MusicManager.this, artist, genre, getSortBy(SortType.ARTIST), getSortOrder());
+				response.value = mc.addToPlaylist(MusicManager.this, artist, genre, sortPreferenceMedia.getSortBy(SortType.ARTIST), sortPreferenceMedia.getSortOrder());
 				checkForPlayAfterQueue(mc, cc, numAlreadyQueued);
 			}
 		});
@@ -454,7 +454,7 @@ public class MusicManager extends AbstractManager implements IMusicManager, ISor
 		mHandler.post(new Command<Boolean>(response, this) {
 			public void doRun() throws Exception{ 
 				control(context).stop(MusicManager.this);
-				response.value = music(context).play(MusicManager.this, album, getSortBy(SortType.TRACK), getSortOrder());
+				response.value = music(context).play(MusicManager.this, album, sortPreferenceMedia.getSortBy(SortType.TRACK), sortPreferenceMedia.getSortOrder());
 			}
 		});
 	}
@@ -468,7 +468,7 @@ public class MusicManager extends AbstractManager implements IMusicManager, ISor
 		mHandler.post(new Command<Boolean>(response, this) {
 			public void doRun() throws Exception{ 
 				control(context).stop(MusicManager.this);
-				response.value = music(context).play(MusicManager.this, genre, getSortBy(SortType.ARTIST), getSortOrder());
+				response.value = music(context).play(MusicManager.this, genre, sortPreferenceMedia.getSortBy(SortType.ARTIST), sortPreferenceMedia.getSortOrder());
 			}
 		});
 	}
@@ -501,7 +501,7 @@ public class MusicManager extends AbstractManager implements IMusicManager, ISor
 				int n = 0;
 				int playPos = 0;
 				mc.clearPlaylist(MusicManager.this);
-				for (Song albumSong : mc.getSongs(MusicManager.this, album, getSortBy(SortType.TRACK), getSortOrder())) {
+				for (Song albumSong : mc.getSongs(MusicManager.this, album, sortPreferenceMedia.getSortBy(SortType.TRACK), sortPreferenceMedia.getSortOrder())) {
 					if (albumSong.id == song.id) {
 						playPos = n;
 						break;
@@ -509,7 +509,7 @@ public class MusicManager extends AbstractManager implements IMusicManager, ISor
 					n++;
 				}
 				cc.stop(MusicManager.this);
-				mc.addToPlaylist(MusicManager.this, album, getSortBy(SortType.TRACK), getSortOrder());
+				mc.addToPlaylist(MusicManager.this, album, sortPreferenceMedia.getSortBy(SortType.TRACK), sortPreferenceMedia.getSortOrder());
 				if (playPos > 0) {
 					response.value = mc.playlistSetSong(MusicManager.this, playPos);
 				}
@@ -529,7 +529,7 @@ public class MusicManager extends AbstractManager implements IMusicManager, ISor
 		mHandler.post(new Command<Boolean>(response, this) {
 			public void doRun() throws Exception{ 
 				control(context).stop(MusicManager.this);
-				response.value = music(context).play(MusicManager.this, artist, getSortBy(SortType.ALBUM), getSortOrder());
+				response.value = music(context).play(MusicManager.this, artist, sortPreferenceMedia.getSortBy(SortType.ALBUM), sortPreferenceMedia.getSortOrder());
 			}
 		});
 	}

--- a/src/org/xbmc/android/remote/business/SortPreferenceMedia.java
+++ b/src/org/xbmc/android/remote/business/SortPreferenceMedia.java
@@ -1,0 +1,73 @@
+package org.xbmc.android.remote.business;
+
+import android.content.SharedPreferences;
+
+import org.xbmc.api.business.ISortableManager;
+import org.xbmc.api.type.SortType;
+
+public class SortPreferenceMedia implements ISortableManager {
+    public static final String PREF_SORT_BY_PREFIX = "sort_by_";
+    public static final String PREF_SORT_ORDER_PREFIX = "sort_order_";
+
+    /* The idea of the sort keys is to remember different sort settings for
+     * each type. In your controller, make sure you run setSortKey() in the
+	 * onCreate() method.
+	 */
+    public static final int PREF_SORT_KEY_ALBUM = 1;
+    public static final int PREF_SORT_KEY_ARTIST = 2;
+    public static final int PREF_SORT_KEY_SONG = 3;
+    public static final int PREF_SORT_KEY_GENRE = 4;
+    public static final int PREF_SORT_KEY_FILEMODE = 5;
+    public static final int PREF_SORT_KEY_SHOW = 6;
+    public static final int PREF_SORT_KEY_MOVIE = 7;
+    public static final int PREF_SORT_KEY_EPISODE = 8;
+
+    public SharedPreferences mPref;
+    public int mCurrentSortKey;
+
+    /**
+     * Sets the static reference to the preferences object. Used to obtain
+     * current sort values.
+     *
+     * @param pref
+     */
+    public void setPreferences(SharedPreferences pref) {
+        mPref = pref;
+    }
+
+    /**
+     * Sets which kind of view is currently active.
+     *
+     * @param sortKey
+     */
+    public void setSortKey(int sortKey) {
+        mCurrentSortKey = sortKey;
+    }
+
+    /**
+     * Returns currently saved "sort by" value. If the preference was not set yet, or
+     * if the current sort key is not set, return default value.
+     *
+     * @param type Default value
+     * @return Sort by field
+     */
+    public int getSortBy(int type) {
+        if (mPref != null) {
+            return mPref.getInt(PREF_SORT_BY_PREFIX + mCurrentSortKey, type);
+        }
+        return type;
+    }
+
+    /**
+     * Returns currently saved "sort by" value. If the preference was not set yet, or
+     * if the current sort key is not set, return "ASC".
+     *
+     * @return Sort order
+     */
+    public String getSortOrder() {
+        if (mPref != null) {
+            return mPref.getString(PREF_SORT_ORDER_PREFIX + mCurrentSortKey, SortType.ORDER_ASC);
+        }
+        return SortType.ORDER_ASC;
+    }
+}

--- a/src/org/xbmc/android/remote/business/TvShowManager.java
+++ b/src/org/xbmc/android/remote/business/TvShowManager.java
@@ -16,8 +16,7 @@ import org.xbmc.httpapi.WifiStateException;
 
 import android.content.Context;
 
-public class TvShowManager extends AbstractManager implements ITvShowManager,
-		ISortableManager, INotifiableManager {
+public class TvShowManager extends AbstractManager implements ITvShowManager, INotifiableManager {
 
 	/**
 	 * Gets all tv shows actors from database
@@ -53,7 +52,7 @@ public class TvShowManager extends AbstractManager implements ITvShowManager,
 		mHandler.post(new Command<ArrayList<TvShow>>(response, this) {
 			@Override
 			public void doRun() throws Exception {
-				response.value = shows(context).getTvShows(TvShowManager.this, getSortBy(SortType.TITLE), getSortOrder(), getHideWatched(context));
+				response.value = shows(context).getTvShows(TvShowManager.this, sortPreferenceMedia.getSortBy(SortType.TITLE), sortPreferenceMedia.getSortOrder(), getHideWatched(context));
 			}
 		});
 	}
@@ -64,7 +63,7 @@ public class TvShowManager extends AbstractManager implements ITvShowManager,
 	 */
 	public ArrayList<TvShow> getTvShows(Context context) {
 		try {
-			return shows(context).getTvShows(TvShowManager.this, getSortBy(SortType.TITLE), getSortOrder(), getHideWatched(context));
+			return shows(context).getTvShows(TvShowManager.this, sortPreferenceMedia.getSortBy(SortType.TITLE), sortPreferenceMedia.getSortOrder(), getHideWatched(context));
 		} catch (WifiStateException e) {
 			TvShowManager.this.onError(e);
 		}
@@ -77,7 +76,7 @@ public class TvShowManager extends AbstractManager implements ITvShowManager,
 	 */
 	public ArrayList<Season> getAllSeasons(Context context) {
 		try {
-			return shows(context).getSeasons(TvShowManager.this, getSortBy(SortType.TITLE), getSortOrder(), getHideWatched(context));
+			return shows(context).getSeasons(TvShowManager.this, sortPreferenceMedia.getSortBy(SortType.TITLE), sortPreferenceMedia.getSortOrder(), getHideWatched(context));
 		} catch (WifiStateException e) {
 			TvShowManager.this.onError(e);
 		}
@@ -90,7 +89,7 @@ public class TvShowManager extends AbstractManager implements ITvShowManager,
 	 */
 	public ArrayList<Episode> getAllEpisodes(Context context) {
 		try {
-			return shows(context).getEpisodes(TvShowManager.this, getSortBy(SortType.EPISODE_NUM), getSortOrder(), getHideWatched(context));
+			return shows(context).getEpisodes(TvShowManager.this, sortPreferenceMedia.getSortBy(SortType.EPISODE_NUM), sortPreferenceMedia.getSortOrder(), getHideWatched(context));
 		} catch (WifiStateException e) {
 			TvShowManager.this.onError(e);
 		}
@@ -106,7 +105,7 @@ public class TvShowManager extends AbstractManager implements ITvShowManager,
 		mHandler.post(new Command<ArrayList<TvShow>>(response, this) {
 			@Override
 			public void doRun() throws Exception {
-				response.value = shows(context).getTvShows(TvShowManager.this, genre, getSortBy(SortType.TITLE), getSortOrder(), getHideWatched(context));
+				response.value = shows(context).getTvShows(TvShowManager.this, genre, sortPreferenceMedia.getSortBy(SortType.TITLE), sortPreferenceMedia.getSortOrder(), getHideWatched(context));
 			}
 		});
 	}
@@ -120,7 +119,7 @@ public class TvShowManager extends AbstractManager implements ITvShowManager,
 		mHandler.post(new Command<ArrayList<TvShow>>(response, this) {
 			@Override
 			public void doRun() throws Exception {
-				mResponse.value = shows(context).getTvShows(TvShowManager.this, actor, getSortBy(SortType.TITLE), getSortOrder(), getHideWatched(context));
+				mResponse.value = shows(context).getTvShows(TvShowManager.this, actor, sortPreferenceMedia.getSortBy(SortType.TITLE), sortPreferenceMedia.getSortOrder(), getHideWatched(context));
 			}
 		});
 	}
@@ -135,7 +134,7 @@ public class TvShowManager extends AbstractManager implements ITvShowManager,
 		mHandler.post(new Command<ArrayList<Episode>>(response, this) {
 			@Override
 			public void doRun() throws Exception {
-				mResponse.value = shows(context).getEpisodes(TvShowManager.this, show, getSortBy(SortType.EPISODE_NUM), getSortOrder(), getHideWatched(context));
+				mResponse.value = shows(context).getEpisodes(TvShowManager.this, show, sortPreferenceMedia.getSortBy(SortType.EPISODE_NUM), sortPreferenceMedia.getSortOrder(), getHideWatched(context));
 			}
 		});
 	}
@@ -166,7 +165,7 @@ public class TvShowManager extends AbstractManager implements ITvShowManager,
 		mHandler.post(new Command<ArrayList<Episode>>(response, this) {
 			@Override
 			public void doRun() throws Exception {
-				mResponse.value = shows(context).getEpisodes(TvShowManager.this, show, season, getSortBy(SortType.EPISODE_NUM), getSortOrder(), getHideWatched(context));
+				mResponse.value = shows(context).getEpisodes(TvShowManager.this, show, season, sortPreferenceMedia.getSortBy(SortType.EPISODE_NUM), sortPreferenceMedia.getSortOrder(), getHideWatched(context));
 			}
 		});
 		
@@ -182,7 +181,7 @@ public class TvShowManager extends AbstractManager implements ITvShowManager,
 		mHandler.post(new Command<ArrayList<Episode>>(response, this) {
 			@Override
 			public void doRun() throws Exception {
-				mResponse.value = shows(context).getEpisodes(TvShowManager.this, season, getSortBy(SortType.EPISODE_NUM), getSortOrder(), getHideWatched(context));
+				mResponse.value = shows(context).getEpisodes(TvShowManager.this, season, sortPreferenceMedia.getSortBy(SortType.EPISODE_NUM), sortPreferenceMedia.getSortOrder(), getHideWatched(context));
 			}
 		});
 	}

--- a/src/org/xbmc/android/remote/business/VideoManager.java
+++ b/src/org/xbmc/android/remote/business/VideoManager.java
@@ -40,7 +40,7 @@ import android.content.Context;
  * 
  * @author Team XBMC
  */
-public class VideoManager extends AbstractManager implements IVideoManager, ISortableManager, INotifiableManager {
+public class VideoManager extends AbstractManager implements IVideoManager, INotifiableManager {
 	
 	/**
 	 * Updates the movie object with additional data (plot, cast, etc)
@@ -64,7 +64,7 @@ public class VideoManager extends AbstractManager implements IVideoManager, ISor
 		mHandler.post(new Command<ArrayList<Movie>>(response, this) {
 			@Override
 			public void doRun() throws Exception { 
-				response.value = video(context).getMovies(VideoManager.this, getSortBy(SortType.TITLE), getSortOrder(), getHideWatched(context));
+				response.value = video(context).getMovies(VideoManager.this, sortPreferenceMedia.getSortBy(SortType.TITLE), sortPreferenceMedia.getSortOrder(), getHideWatched(context));
 			}
 		});
 	}
@@ -75,7 +75,7 @@ public class VideoManager extends AbstractManager implements IVideoManager, ISor
 	 */
 	public ArrayList<Movie> getMovies(final Context context) {
 		try {
-			return video(context).getMovies(VideoManager.this, getSortBy(SortType.TITLE), getSortOrder(), getHideWatched(context));
+			return video(context).getMovies(VideoManager.this, sortPreferenceMedia.getSortBy(SortType.TITLE), sortPreferenceMedia.getSortOrder(), getHideWatched(context));
 		} catch (WifiStateException e) {
 			e.printStackTrace();
 		}
@@ -88,7 +88,7 @@ public class VideoManager extends AbstractManager implements IVideoManager, ISor
 	 */
 	public ArrayList<Movie> getMovies(final Context context, int offset) {
 		try {
-			return video(context).getMovies(VideoManager.this, getSortBy(SortType.TITLE), getSortOrder(), offset, getHideWatched(context));
+			return video(context).getMovies(VideoManager.this, sortPreferenceMedia.getSortBy(SortType.TITLE), sortPreferenceMedia.getSortOrder(), offset, getHideWatched(context));
 		} catch (WifiStateException e) {
 			e.printStackTrace();
 		}
@@ -104,7 +104,7 @@ public class VideoManager extends AbstractManager implements IVideoManager, ISor
 		mHandler.post(new Command<ArrayList<Movie>>(response, this) {
 			@Override
 			public void doRun() throws Exception { 
-				response.value = video(context).getMovies(VideoManager.this, actor, getSortBy(SortType.TITLE), getSortOrder(), getHideWatched(context));
+				response.value = video(context).getMovies(VideoManager.this, actor, sortPreferenceMedia.getSortBy(SortType.TITLE), sortPreferenceMedia.getSortOrder(), getHideWatched(context));
 			}
 		});
 	}
@@ -118,7 +118,7 @@ public class VideoManager extends AbstractManager implements IVideoManager, ISor
 		mHandler.post(new Command<ArrayList<Movie>>(response, this) {
 			@Override
 			public void doRun() throws Exception { 
-				response.value = video(context).getMovies(VideoManager.this, genre, getSortBy(SortType.TITLE), getSortOrder(), getHideWatched(context));
+				response.value = video(context).getMovies(VideoManager.this, genre, sortPreferenceMedia.getSortBy(SortType.TITLE), sortPreferenceMedia.getSortOrder(), getHideWatched(context));
 			}
 		});
 	}

--- a/src/org/xbmc/android/remote/presentation/controller/AlbumListController.java
+++ b/src/org/xbmc/android/remote/presentation/controller/AlbumListController.java
@@ -24,8 +24,8 @@ package org.xbmc.android.remote.presentation.controller;
 import java.util.ArrayList;
 
 import org.xbmc.android.remote.R;
-import org.xbmc.android.remote.business.AbstractManager;
 import org.xbmc.android.remote.business.ManagerFactory;
+import org.xbmc.android.remote.business.SortPreferenceMedia;
 import org.xbmc.android.remote.presentation.activity.DialogFactory;
 import org.xbmc.android.remote.presentation.activity.ListActivity;
 import org.xbmc.android.remote.presentation.widget.ThreeLabelsItemView;
@@ -126,7 +126,7 @@ public class AlbumListController extends ListController implements IController {
 		mMusicManager = ManagerFactory.getMusicManager(this);
 		mControlManager = ManagerFactory.getControlManager(this);
 		
-		((ISortableManager)mMusicManager).setSortKey(AbstractManager.PREF_SORT_KEY_ALBUM);
+		((ISortableManager)mMusicManager).setSortKey(SortPreferenceMedia.PREF_SORT_KEY_ALBUM);
 		((ISortableManager)mMusicManager).setPreferences(activity.getPreferences(Context.MODE_PRIVATE));
 		
 		final String sdError = ImportUtilities.assertSdCard();
@@ -327,43 +327,43 @@ public class AlbumListController extends ListController implements IController {
 			break;
 		case MENU_SORT_BY_ALBUM_ASC:
 			ed = mActivity.getPreferences(Context.MODE_PRIVATE).edit();
-			ed.putInt(AbstractManager.PREF_SORT_BY_PREFIX + AbstractManager.PREF_SORT_KEY_ALBUM, SortType.ALBUM);
-			ed.putString(AbstractManager.PREF_SORT_ORDER_PREFIX + AbstractManager.PREF_SORT_KEY_ALBUM, SortType.ORDER_ASC);
+			ed.putInt(SortPreferenceMedia.PREF_SORT_BY_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_ALBUM, SortType.ALBUM);
+			ed.putString(SortPreferenceMedia.PREF_SORT_ORDER_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_ALBUM, SortType.ORDER_ASC);
 			ed.commit();
 			fetch();
 			break;
 		case MENU_SORT_BY_ALBUM_DESC:
 			ed = mActivity.getPreferences(Context.MODE_PRIVATE).edit();
-			ed.putInt(AbstractManager.PREF_SORT_BY_PREFIX + AbstractManager.PREF_SORT_KEY_ALBUM, SortType.ALBUM);
-			ed.putString(AbstractManager.PREF_SORT_ORDER_PREFIX + AbstractManager.PREF_SORT_KEY_ALBUM, SortType.ORDER_DESC);
+			ed.putInt(SortPreferenceMedia.PREF_SORT_BY_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_ALBUM, SortType.ALBUM);
+			ed.putString(SortPreferenceMedia.PREF_SORT_ORDER_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_ALBUM, SortType.ORDER_DESC);
 			ed.commit();
 			fetch();
 			break;
 		case MENU_SORT_BY_ARTIST_ASC:
 			ed = mActivity.getPreferences(Context.MODE_PRIVATE).edit();
-			ed.putInt(AbstractManager.PREF_SORT_BY_PREFIX + AbstractManager.PREF_SORT_KEY_ALBUM, SortType.ARTIST);
-			ed.putString(AbstractManager.PREF_SORT_ORDER_PREFIX + AbstractManager.PREF_SORT_KEY_ALBUM, SortType.ORDER_ASC);
+			ed.putInt(SortPreferenceMedia.PREF_SORT_BY_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_ALBUM, SortType.ARTIST);
+			ed.putString(SortPreferenceMedia.PREF_SORT_ORDER_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_ALBUM, SortType.ORDER_ASC);
 			ed.commit();
 			fetch();
 			break;
 		case MENU_SORT_BY_ARTIST_DESC:
 			ed = mActivity.getPreferences(Context.MODE_PRIVATE).edit();
-			ed.putInt(AbstractManager.PREF_SORT_BY_PREFIX + AbstractManager.PREF_SORT_KEY_ALBUM, SortType.ARTIST);
-			ed.putString(AbstractManager.PREF_SORT_ORDER_PREFIX + AbstractManager.PREF_SORT_KEY_ALBUM, SortType.ORDER_DESC);
+			ed.putInt(SortPreferenceMedia.PREF_SORT_BY_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_ALBUM, SortType.ARTIST);
+			ed.putString(SortPreferenceMedia.PREF_SORT_ORDER_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_ALBUM, SortType.ORDER_DESC);
 			ed.commit();
 			fetch();
 			break;
 		case MENU_SORT_BY_YEAR_ASC:
 			ed = mActivity.getPreferences(Context.MODE_PRIVATE).edit();
-			ed.putInt(AbstractManager.PREF_SORT_BY_PREFIX + AbstractManager.PREF_SORT_KEY_ALBUM, SortType.YEAR);
-			ed.putString(AbstractManager.PREF_SORT_ORDER_PREFIX + AbstractManager.PREF_SORT_KEY_ALBUM, SortType.ORDER_ASC);
+			ed.putInt(SortPreferenceMedia.PREF_SORT_BY_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_ALBUM, SortType.YEAR);
+			ed.putString(SortPreferenceMedia.PREF_SORT_ORDER_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_ALBUM, SortType.ORDER_ASC);
 			ed.commit();
 			fetch();
 			break;
 		case MENU_SORT_BY_YEAR_DESC:
 			ed = mActivity.getPreferences(Context.MODE_PRIVATE).edit();
-			ed.putInt(AbstractManager.PREF_SORT_BY_PREFIX + AbstractManager.PREF_SORT_KEY_ALBUM, SortType.YEAR);
-			ed.putString(AbstractManager.PREF_SORT_ORDER_PREFIX + AbstractManager.PREF_SORT_KEY_ALBUM, SortType.ORDER_DESC);
+			ed.putInt(SortPreferenceMedia.PREF_SORT_BY_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_ALBUM, SortType.YEAR);
+			ed.putString(SortPreferenceMedia.PREF_SORT_ORDER_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_ALBUM, SortType.ORDER_DESC);
 			ed.commit();
 			fetch();
 			break;

--- a/src/org/xbmc/android/remote/presentation/controller/EpisodeListController.java
+++ b/src/org/xbmc/android/remote/presentation/controller/EpisodeListController.java
@@ -24,8 +24,8 @@ package org.xbmc.android.remote.presentation.controller;
 import java.util.ArrayList;
 
 import org.xbmc.android.remote.R;
-import org.xbmc.android.remote.business.AbstractManager;
 import org.xbmc.android.remote.business.ManagerFactory;
+import org.xbmc.android.remote.business.SortPreferenceMedia;
 import org.xbmc.android.remote.presentation.activity.EpisodeDetailsActivity;
 import org.xbmc.android.remote.presentation.activity.NowPlayingActivity;
 import org.xbmc.android.remote.presentation.widget.FiveLabelsItemView;
@@ -134,7 +134,7 @@ public class EpisodeListController extends ListController implements IController
 	
 	private void fetch() {		
 		// tv show and episode both are using the same manager so set the sort key here
-		((ISortableManager)mTvManager).setSortKey(AbstractManager.PREF_SORT_KEY_EPISODE);
+		((ISortableManager)mTvManager).setSortKey(SortPreferenceMedia.PREF_SORT_KEY_EPISODE);
 		((ISortableManager)mTvManager).setPreferences(mActivity.getPreferences(Context.MODE_PRIVATE));
 		
 		final String title = mSeason != null ? mSeason.getName() + " - " : "" + "Episodes";
@@ -267,43 +267,43 @@ public class EpisodeListController extends ListController implements IController
 			break;
 		case MENU_SORT_BY_EPISODE_ASC:
 			ed = mActivity.getPreferences(Context.MODE_PRIVATE).edit();
-			ed.putInt(AbstractManager.PREF_SORT_BY_PREFIX + AbstractManager.PREF_SORT_KEY_EPISODE, SortType.EPISODE_NUM);
-			ed.putString(AbstractManager.PREF_SORT_ORDER_PREFIX + AbstractManager.PREF_SORT_KEY_EPISODE, SortType.ORDER_ASC);
+			ed.putInt(SortPreferenceMedia.PREF_SORT_BY_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_EPISODE, SortType.EPISODE_NUM);
+			ed.putString(SortPreferenceMedia.PREF_SORT_ORDER_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_EPISODE, SortType.ORDER_ASC);
 			ed.commit();
 			fetch();
 			break;
 		case MENU_SORT_BY_EPISODE_DESC:
 			ed = mActivity.getPreferences(Context.MODE_PRIVATE).edit();
-			ed.putInt(AbstractManager.PREF_SORT_BY_PREFIX + AbstractManager.PREF_SORT_KEY_EPISODE, SortType.EPISODE_NUM);
-			ed.putString(AbstractManager.PREF_SORT_ORDER_PREFIX + AbstractManager.PREF_SORT_KEY_EPISODE, SortType.ORDER_DESC);
+			ed.putInt(SortPreferenceMedia.PREF_SORT_BY_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_EPISODE, SortType.EPISODE_NUM);
+			ed.putString(SortPreferenceMedia.PREF_SORT_ORDER_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_EPISODE, SortType.ORDER_DESC);
 			ed.commit();
 			fetch();
 			break;
 		case MENU_SORT_BY_TITLE_ASC:
 			ed = mActivity.getPreferences(Context.MODE_PRIVATE).edit();
-			ed.putInt(AbstractManager.PREF_SORT_BY_PREFIX + AbstractManager.PREF_SORT_KEY_EPISODE, SortType.EPISODE_TITLE);
-			ed.putString(AbstractManager.PREF_SORT_ORDER_PREFIX + AbstractManager.PREF_SORT_KEY_EPISODE, SortType.ORDER_ASC);
+			ed.putInt(SortPreferenceMedia.PREF_SORT_BY_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_EPISODE, SortType.EPISODE_TITLE);
+			ed.putString(SortPreferenceMedia.PREF_SORT_ORDER_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_EPISODE, SortType.ORDER_ASC);
 			ed.commit();
 			fetch();
 			break;
 		case MENU_SORT_BY_TITLE_DESC:
 			ed = mActivity.getPreferences(Context.MODE_PRIVATE).edit();
-			ed.putInt(AbstractManager.PREF_SORT_BY_PREFIX + AbstractManager.PREF_SORT_KEY_EPISODE, SortType.EPISODE_TITLE);
-			ed.putString(AbstractManager.PREF_SORT_ORDER_PREFIX + AbstractManager.PREF_SORT_KEY_EPISODE, SortType.ORDER_DESC);
+			ed.putInt(SortPreferenceMedia.PREF_SORT_BY_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_EPISODE, SortType.EPISODE_TITLE);
+			ed.putString(SortPreferenceMedia.PREF_SORT_ORDER_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_EPISODE, SortType.ORDER_DESC);
 			ed.commit();
 			fetch();
 			break;
 		case MENU_SORT_BY_RATING_ASC:
 			ed = mActivity.getPreferences(Context.MODE_PRIVATE).edit();
-			ed.putInt(AbstractManager.PREF_SORT_BY_PREFIX + AbstractManager.PREF_SORT_KEY_EPISODE, SortType.EPISODE_RATING);
-			ed.putString(AbstractManager.PREF_SORT_ORDER_PREFIX + AbstractManager.PREF_SORT_KEY_EPISODE, SortType.ORDER_ASC);
+			ed.putInt(SortPreferenceMedia.PREF_SORT_BY_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_EPISODE, SortType.EPISODE_RATING);
+			ed.putString(SortPreferenceMedia.PREF_SORT_ORDER_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_EPISODE, SortType.ORDER_ASC);
 			ed.commit();
 			fetch();
 			break;
 		case MENU_SORT_BY_RATING_DESC:
 			ed = mActivity.getPreferences(Context.MODE_PRIVATE).edit();
-			ed.putInt(AbstractManager.PREF_SORT_BY_PREFIX + AbstractManager.PREF_SORT_KEY_EPISODE, SortType.EPISODE_RATING);
-			ed.putString(AbstractManager.PREF_SORT_ORDER_PREFIX + AbstractManager.PREF_SORT_KEY_SHOW, SortType.ORDER_DESC);
+			ed.putInt(SortPreferenceMedia.PREF_SORT_BY_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_EPISODE, SortType.EPISODE_RATING);
+			ed.putString(SortPreferenceMedia.PREF_SORT_ORDER_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_SHOW, SortType.ORDER_DESC);
 			ed.commit();
 			fetch();
 			break;

--- a/src/org/xbmc/android/remote/presentation/controller/MovieListController.java
+++ b/src/org/xbmc/android/remote/presentation/controller/MovieListController.java
@@ -24,8 +24,8 @@ package org.xbmc.android.remote.presentation.controller;
 import java.util.ArrayList;
 
 import org.xbmc.android.remote.R;
-import org.xbmc.android.remote.business.AbstractManager;
 import org.xbmc.android.remote.business.ManagerFactory;
+import org.xbmc.android.remote.business.SortPreferenceMedia;
 import org.xbmc.android.remote.presentation.activity.MovieDetailsActivity;
 import org.xbmc.android.remote.presentation.activity.NowPlayingActivity;
 import org.xbmc.android.remote.presentation.widget.FiveLabelsItemView;
@@ -100,7 +100,7 @@ public class MovieListController extends ListController implements IController {
 		mVideoManager = ManagerFactory.getVideoManager(this);
 		mControlManager = ManagerFactory.getControlManager(this);
 		
-		((ISortableManager)mVideoManager).setSortKey(AbstractManager.PREF_SORT_KEY_MOVIE);
+		((ISortableManager)mVideoManager).setSortKey(SortPreferenceMedia.PREF_SORT_KEY_MOVIE);
 		((ISortableManager)mVideoManager).setPreferences(activity.getPreferences(Context.MODE_PRIVATE));
 		
 		final String sdError = ImportUtilities.assertSdCard();
@@ -273,57 +273,57 @@ public class MovieListController extends ListController implements IController {
 			break;
 		case MENU_SORT_BY_TITLE_ASC:
 			ed = mActivity.getPreferences(Context.MODE_PRIVATE).edit();
-			ed.putInt(AbstractManager.PREF_SORT_BY_PREFIX + AbstractManager.PREF_SORT_KEY_MOVIE, SortType.TITLE);
-			ed.putString(AbstractManager.PREF_SORT_ORDER_PREFIX + AbstractManager.PREF_SORT_KEY_MOVIE, SortType.ORDER_ASC);
+			ed.putInt(SortPreferenceMedia.PREF_SORT_BY_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_MOVIE, SortType.TITLE);
+			ed.putString(SortPreferenceMedia.PREF_SORT_ORDER_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_MOVIE, SortType.ORDER_ASC);
 			ed.commit();
 			fetch();
 			break;
 		case MENU_SORT_BY_TITLE_DESC:
 			ed = mActivity.getPreferences(Context.MODE_PRIVATE).edit();
-			ed.putInt(AbstractManager.PREF_SORT_BY_PREFIX + AbstractManager.PREF_SORT_KEY_MOVIE, SortType.TITLE);
-			ed.putString(AbstractManager.PREF_SORT_ORDER_PREFIX + AbstractManager.PREF_SORT_KEY_MOVIE, SortType.ORDER_DESC);
+			ed.putInt(SortPreferenceMedia.PREF_SORT_BY_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_MOVIE, SortType.TITLE);
+			ed.putString(SortPreferenceMedia.PREF_SORT_ORDER_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_MOVIE, SortType.ORDER_DESC);
 			ed.commit();
 			fetch();
 			break;
 		case MENU_SORT_BY_YEAR_ASC:
 			ed = mActivity.getPreferences(Context.MODE_PRIVATE).edit();
-			ed.putInt(AbstractManager.PREF_SORT_BY_PREFIX + AbstractManager.PREF_SORT_KEY_MOVIE, SortType.YEAR);
-			ed.putString(AbstractManager.PREF_SORT_ORDER_PREFIX + AbstractManager.PREF_SORT_KEY_MOVIE, SortType.ORDER_ASC);
+			ed.putInt(SortPreferenceMedia.PREF_SORT_BY_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_MOVIE, SortType.YEAR);
+			ed.putString(SortPreferenceMedia.PREF_SORT_ORDER_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_MOVIE, SortType.ORDER_ASC);
 			ed.commit();
 			fetch();
 			break;
 		case MENU_SORT_BY_YEAR_DESC:
 			ed = mActivity.getPreferences(Context.MODE_PRIVATE).edit();
-			ed.putInt(AbstractManager.PREF_SORT_BY_PREFIX + AbstractManager.PREF_SORT_KEY_MOVIE, SortType.YEAR);
-			ed.putString(AbstractManager.PREF_SORT_ORDER_PREFIX + AbstractManager.PREF_SORT_KEY_MOVIE, SortType.ORDER_DESC);
+			ed.putInt(SortPreferenceMedia.PREF_SORT_BY_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_MOVIE, SortType.YEAR);
+			ed.putString(SortPreferenceMedia.PREF_SORT_ORDER_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_MOVIE, SortType.ORDER_DESC);
 			ed.commit();
 			fetch();
 			break;
 		case MENU_SORT_BY_RATING_ASC:
 			ed = mActivity.getPreferences(Context.MODE_PRIVATE).edit();
-			ed.putInt(AbstractManager.PREF_SORT_BY_PREFIX + AbstractManager.PREF_SORT_KEY_MOVIE, SortType.RATING);
-			ed.putString(AbstractManager.PREF_SORT_ORDER_PREFIX + AbstractManager.PREF_SORT_KEY_MOVIE, SortType.ORDER_ASC);
+			ed.putInt(SortPreferenceMedia.PREF_SORT_BY_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_MOVIE, SortType.RATING);
+			ed.putString(SortPreferenceMedia.PREF_SORT_ORDER_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_MOVIE, SortType.ORDER_ASC);
 			ed.commit();
 			fetch();
 			break;
 		case MENU_SORT_BY_RATING_DESC:
 			ed = mActivity.getPreferences(Context.MODE_PRIVATE).edit();
-			ed.putInt(AbstractManager.PREF_SORT_BY_PREFIX + AbstractManager.PREF_SORT_KEY_MOVIE, SortType.RATING);
-			ed.putString(AbstractManager.PREF_SORT_ORDER_PREFIX + AbstractManager.PREF_SORT_KEY_MOVIE, SortType.ORDER_DESC);
+			ed.putInt(SortPreferenceMedia.PREF_SORT_BY_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_MOVIE, SortType.RATING);
+			ed.putString(SortPreferenceMedia.PREF_SORT_ORDER_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_MOVIE, SortType.ORDER_DESC);
 			ed.commit();
 			fetch();
 			break;
 		case MENU_SORT_BY_DATE_ADDED_ASC:
 			ed = mActivity.getPreferences(Context.MODE_PRIVATE).edit();
-			ed.putInt(AbstractManager.PREF_SORT_BY_PREFIX + AbstractManager.PREF_SORT_KEY_MOVIE, SortType.DATE_ADDED);
-			ed.putString(AbstractManager.PREF_SORT_ORDER_PREFIX + AbstractManager.PREF_SORT_KEY_MOVIE, SortType.ORDER_ASC);
+			ed.putInt(SortPreferenceMedia.PREF_SORT_BY_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_MOVIE, SortType.DATE_ADDED);
+			ed.putString(SortPreferenceMedia.PREF_SORT_ORDER_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_MOVIE, SortType.ORDER_ASC);
 			ed.commit();
 			fetch();
 			break;
 		case MENU_SORT_BY_DATE_ADDED_DESC:
 			ed = mActivity.getPreferences(Context.MODE_PRIVATE).edit();
-			ed.putInt(AbstractManager.PREF_SORT_BY_PREFIX + AbstractManager.PREF_SORT_KEY_MOVIE, SortType.DATE_ADDED);
-			ed.putString(AbstractManager.PREF_SORT_ORDER_PREFIX + AbstractManager.PREF_SORT_KEY_MOVIE, SortType.ORDER_DESC);
+			ed.putInt(SortPreferenceMedia.PREF_SORT_BY_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_MOVIE, SortType.DATE_ADDED);
+			ed.putString(SortPreferenceMedia.PREF_SORT_ORDER_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_MOVIE, SortType.ORDER_DESC);
 			ed.commit();
 			fetch();
 			break;

--- a/src/org/xbmc/android/remote/presentation/controller/SongListController.java
+++ b/src/org/xbmc/android/remote/presentation/controller/SongListController.java
@@ -24,8 +24,8 @@ package org.xbmc.android.remote.presentation.controller;
 import java.util.ArrayList;
 
 import org.xbmc.android.remote.R;
-import org.xbmc.android.remote.business.AbstractManager;
 import org.xbmc.android.remote.business.ManagerFactory;
+import org.xbmc.android.remote.business.SortPreferenceMedia;
 import org.xbmc.android.remote.presentation.widget.ThreeLabelsItemView;
 import org.xbmc.android.util.ImportUtilities;
 import org.xbmc.api.business.DataResponse;
@@ -95,7 +95,7 @@ public class SongListController extends ListController implements IController {
 		
 		mMusicManager = ManagerFactory.getMusicManager(this);
 		
-		((ISortableManager)mMusicManager).setSortKey(AbstractManager.PREF_SORT_KEY_SONG);
+		((ISortableManager)mMusicManager).setSortKey(SortPreferenceMedia.PREF_SORT_KEY_SONG);
 		((ISortableManager)mMusicManager).setPreferences(activity.getPreferences(Context.MODE_PRIVATE));
 		
 		final String sdError = ImportUtilities.assertSdCard();
@@ -276,57 +276,57 @@ public class SongListController extends ListController implements IController {
 			break;
 		case MENU_SORT_BY_ALBUM_ASC:
 			ed = mActivity.getPreferences(Context.MODE_PRIVATE).edit();
-			ed.putInt(AbstractManager.PREF_SORT_BY_PREFIX + AbstractManager.PREF_SORT_KEY_SONG, SortType.ALBUM);
-			ed.putString(AbstractManager.PREF_SORT_ORDER_PREFIX + AbstractManager.PREF_SORT_KEY_SONG, SortType.ORDER_ASC);
+			ed.putInt(SortPreferenceMedia.PREF_SORT_BY_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_SONG, SortType.ALBUM);
+			ed.putString(SortPreferenceMedia.PREF_SORT_ORDER_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_SONG, SortType.ORDER_ASC);
 			ed.commit();
 			fetch();
 			break;
 		case MENU_SORT_BY_ALBUM_DESC:
 			ed = mActivity.getPreferences(Context.MODE_PRIVATE).edit();
-			ed.putInt(AbstractManager.PREF_SORT_BY_PREFIX + AbstractManager.PREF_SORT_KEY_SONG, SortType.ALBUM);
-			ed.putString(AbstractManager.PREF_SORT_ORDER_PREFIX + AbstractManager.PREF_SORT_KEY_SONG, SortType.ORDER_DESC);
+			ed.putInt(SortPreferenceMedia.PREF_SORT_BY_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_SONG, SortType.ALBUM);
+			ed.putString(SortPreferenceMedia.PREF_SORT_ORDER_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_SONG, SortType.ORDER_DESC);
 			ed.commit();
 			fetch();
 			break;
 		case MENU_SORT_BY_ARTIST_ASC:
 			ed = mActivity.getPreferences(Context.MODE_PRIVATE).edit();
-			ed.putInt(AbstractManager.PREF_SORT_BY_PREFIX + AbstractManager.PREF_SORT_KEY_SONG, SortType.ARTIST);
-			ed.putString(AbstractManager.PREF_SORT_ORDER_PREFIX + AbstractManager.PREF_SORT_KEY_SONG, SortType.ORDER_ASC);
+			ed.putInt(SortPreferenceMedia.PREF_SORT_BY_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_SONG, SortType.ARTIST);
+			ed.putString(SortPreferenceMedia.PREF_SORT_ORDER_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_SONG, SortType.ORDER_ASC);
 			ed.commit();
 			fetch();
 			break;
 		case MENU_SORT_BY_ARTIST_DESC:
 			ed = mActivity.getPreferences(Context.MODE_PRIVATE).edit();
-			ed.putInt(AbstractManager.PREF_SORT_BY_PREFIX + AbstractManager.PREF_SORT_KEY_SONG, SortType.ARTIST);
-			ed.putString(AbstractManager.PREF_SORT_ORDER_PREFIX + AbstractManager.PREF_SORT_KEY_SONG, SortType.ORDER_DESC);
+			ed.putInt(SortPreferenceMedia.PREF_SORT_BY_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_SONG, SortType.ARTIST);
+			ed.putString(SortPreferenceMedia.PREF_SORT_ORDER_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_SONG, SortType.ORDER_DESC);
 			ed.commit();
 			fetch();
 			break;
 		case MENU_SORT_BY_TITLE_ASC:
 			ed = mActivity.getPreferences(Context.MODE_PRIVATE).edit();
-			ed.putInt(AbstractManager.PREF_SORT_BY_PREFIX + AbstractManager.PREF_SORT_KEY_SONG, SortType.TITLE);
-			ed.putString(AbstractManager.PREF_SORT_ORDER_PREFIX + AbstractManager.PREF_SORT_KEY_SONG, SortType.ORDER_ASC);
+			ed.putInt(SortPreferenceMedia.PREF_SORT_BY_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_SONG, SortType.TITLE);
+			ed.putString(SortPreferenceMedia.PREF_SORT_ORDER_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_SONG, SortType.ORDER_ASC);
 			ed.commit();
 			fetch();
 			break;
 		case MENU_SORT_BY_TITLE_DESC:
 			ed = mActivity.getPreferences(Context.MODE_PRIVATE).edit();
-			ed.putInt(AbstractManager.PREF_SORT_BY_PREFIX + AbstractManager.PREF_SORT_KEY_SONG, SortType.TITLE);
-			ed.putString(AbstractManager.PREF_SORT_ORDER_PREFIX + AbstractManager.PREF_SORT_KEY_SONG, SortType.ORDER_DESC);
+			ed.putInt(SortPreferenceMedia.PREF_SORT_BY_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_SONG, SortType.TITLE);
+			ed.putString(SortPreferenceMedia.PREF_SORT_ORDER_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_SONG, SortType.ORDER_DESC);
 			ed.commit();
 			fetch();
 			break;
 		case MENU_SORT_BY_FILENAME_ASC:
 			ed = mActivity.getPreferences(Context.MODE_PRIVATE).edit();
-			ed.putInt(AbstractManager.PREF_SORT_BY_PREFIX + AbstractManager.PREF_SORT_KEY_SONG, SortType.FILENAME);
-			ed.putString(AbstractManager.PREF_SORT_ORDER_PREFIX + AbstractManager.PREF_SORT_KEY_SONG, SortType.ORDER_ASC);
+			ed.putInt(SortPreferenceMedia.PREF_SORT_BY_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_SONG, SortType.FILENAME);
+			ed.putString(SortPreferenceMedia.PREF_SORT_ORDER_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_SONG, SortType.ORDER_ASC);
 			ed.commit();
 			fetch();
 			break;
 		case MENU_SORT_BY_FILENAME_DESC:
 			ed = mActivity.getPreferences(Context.MODE_PRIVATE).edit();
-			ed.putInt(AbstractManager.PREF_SORT_BY_PREFIX + AbstractManager.PREF_SORT_KEY_SONG, SortType.FILENAME);
-			ed.putString(AbstractManager.PREF_SORT_ORDER_PREFIX + AbstractManager.PREF_SORT_KEY_SONG, SortType.ORDER_DESC);
+			ed.putInt(SortPreferenceMedia.PREF_SORT_BY_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_SONG, SortType.FILENAME);
+			ed.putString(SortPreferenceMedia.PREF_SORT_ORDER_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_SONG, SortType.ORDER_DESC);
 			ed.commit();
 			fetch();
 			break;

--- a/src/org/xbmc/android/remote/presentation/controller/TvShowListController.java
+++ b/src/org/xbmc/android/remote/presentation/controller/TvShowListController.java
@@ -24,8 +24,8 @@ package org.xbmc.android.remote.presentation.controller;
 import java.util.ArrayList;
 
 import org.xbmc.android.remote.R;
-import org.xbmc.android.remote.business.AbstractManager;
 import org.xbmc.android.remote.business.ManagerFactory;
+import org.xbmc.android.remote.business.SortPreferenceMedia;
 import org.xbmc.android.remote.presentation.activity.GridActivity;
 import org.xbmc.android.remote.presentation.activity.ListActivity;
 import org.xbmc.android.remote.presentation.activity.TvShowDetailsActivity;
@@ -136,7 +136,7 @@ public class TvShowListController extends ListController implements IController 
 	
 	private void fetch() {
 		// tv show and episode both are using the same manager so set the sort key here
-		((ISortableManager)mTvManager).setSortKey(AbstractManager.PREF_SORT_KEY_SHOW);
+		((ISortableManager)mTvManager).setSortKey(SortPreferenceMedia.PREF_SORT_KEY_SHOW);
 		((ISortableManager)mTvManager).setPreferences(mActivity.getPreferences(Context.MODE_PRIVATE));
 
 		final String title = mActor != null ? mActor.name + " - " : mGenre != null ? mGenre.name + " - " : "" + "TV Shows";
@@ -256,43 +256,43 @@ public class TvShowListController extends ListController implements IController 
 			break;
 		case MENU_SORT_BY_TITLE_ASC:
 			ed = mActivity.getPreferences(Context.MODE_PRIVATE).edit();
-			ed.putInt(AbstractManager.PREF_SORT_BY_PREFIX + AbstractManager.PREF_SORT_KEY_SHOW, SortType.TITLE);
-			ed.putString(AbstractManager.PREF_SORT_ORDER_PREFIX + AbstractManager.PREF_SORT_KEY_SHOW, SortType.ORDER_ASC);
+			ed.putInt(SortPreferenceMedia.PREF_SORT_BY_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_SHOW, SortType.TITLE);
+			ed.putString(SortPreferenceMedia.PREF_SORT_ORDER_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_SHOW, SortType.ORDER_ASC);
 			ed.commit();
 			fetch();
 			break;
 		case MENU_SORT_BY_TITLE_DESC:
 			ed = mActivity.getPreferences(Context.MODE_PRIVATE).edit();
-			ed.putInt(AbstractManager.PREF_SORT_BY_PREFIX + AbstractManager.PREF_SORT_KEY_SHOW, SortType.TITLE);
-			ed.putString(AbstractManager.PREF_SORT_ORDER_PREFIX + AbstractManager.PREF_SORT_KEY_SHOW, SortType.ORDER_DESC);
+			ed.putInt(SortPreferenceMedia.PREF_SORT_BY_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_SHOW, SortType.TITLE);
+			ed.putString(SortPreferenceMedia.PREF_SORT_ORDER_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_SHOW, SortType.ORDER_DESC);
 			ed.commit();
 			fetch();
 			break;
 		case MENU_SORT_BY_YEAR_ASC:
 			ed = mActivity.getPreferences(Context.MODE_PRIVATE).edit();
-			ed.putInt(AbstractManager.PREF_SORT_BY_PREFIX + AbstractManager.PREF_SORT_KEY_SHOW, SortType.YEAR);
-			ed.putString(AbstractManager.PREF_SORT_ORDER_PREFIX + AbstractManager.PREF_SORT_KEY_SHOW, SortType.ORDER_ASC);
+			ed.putInt(SortPreferenceMedia.PREF_SORT_BY_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_SHOW, SortType.YEAR);
+			ed.putString(SortPreferenceMedia.PREF_SORT_ORDER_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_SHOW, SortType.ORDER_ASC);
 			ed.commit();
 			fetch();
 			break;
 		case MENU_SORT_BY_YEAR_DESC:
 			ed = mActivity.getPreferences(Context.MODE_PRIVATE).edit();
-			ed.putInt(AbstractManager.PREF_SORT_BY_PREFIX + AbstractManager.PREF_SORT_KEY_SHOW, SortType.YEAR);
-			ed.putString(AbstractManager.PREF_SORT_ORDER_PREFIX + AbstractManager.PREF_SORT_KEY_SHOW, SortType.ORDER_DESC);
+			ed.putInt(SortPreferenceMedia.PREF_SORT_BY_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_SHOW, SortType.YEAR);
+			ed.putString(SortPreferenceMedia.PREF_SORT_ORDER_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_SHOW, SortType.ORDER_DESC);
 			ed.commit();
 			fetch();
 			break;
 		case MENU_SORT_BY_RATING_ASC:
 			ed = mActivity.getPreferences(Context.MODE_PRIVATE).edit();
-			ed.putInt(AbstractManager.PREF_SORT_BY_PREFIX + AbstractManager.PREF_SORT_KEY_SHOW, SortType.RATING);
-			ed.putString(AbstractManager.PREF_SORT_ORDER_PREFIX + AbstractManager.PREF_SORT_KEY_SHOW, SortType.ORDER_ASC);
+			ed.putInt(SortPreferenceMedia.PREF_SORT_BY_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_SHOW, SortType.RATING);
+			ed.putString(SortPreferenceMedia.PREF_SORT_ORDER_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_SHOW, SortType.ORDER_ASC);
 			ed.commit();
 			fetch();
 			break;
 		case MENU_SORT_BY_RATING_DESC:
 			ed = mActivity.getPreferences(Context.MODE_PRIVATE).edit();
-			ed.putInt(AbstractManager.PREF_SORT_BY_PREFIX + AbstractManager.PREF_SORT_KEY_SHOW, SortType.RATING);
-			ed.putString(AbstractManager.PREF_SORT_ORDER_PREFIX + AbstractManager.PREF_SORT_KEY_SHOW, SortType.ORDER_DESC);
+			ed.putInt(SortPreferenceMedia.PREF_SORT_BY_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_SHOW, SortType.RATING);
+			ed.putString(SortPreferenceMedia.PREF_SORT_ORDER_PREFIX + SortPreferenceMedia.PREF_SORT_KEY_SHOW, SortType.ORDER_DESC);
 			ed.commit();
 			fetch();
 			break;


### PR DESCRIPTION
Added a patchset for the refactoring in the patchset folder, here is a rundown:

[PATCH 0/3] 
- AbstractManager is a Large Class (Code Smell) and it has more than one responsibility.
  Therefore, we extracted Sort attributes and methods to a new class called SortPreferenceMedia.

[PATCH 1/3] Added Preferences For IDE to Ignore File
- Added files to the .gitignore from the preferences that were created by Android Studio

[PATCH 2/3] Refactored AbstractManager
- Extracted KEY_SORT attributes to a new class called SortPreferenceMedia
- Removed Interface ISortableManager from the child classes of AbstractManager

PATCH 3/3] Removed Sort Methods From AbstractManager
- Removed Unnecessary method getSortOrder from AbstractManager
